### PR TITLE
Load fixes on publish power event

### DIFF
--- a/dashboard/frontend/src/components/App.styles.js
+++ b/dashboard/frontend/src/components/App.styles.js
@@ -11,7 +11,6 @@ const styles = theme => ({
     display: 'flex',
     width: '100%',
   },
-  toolbar: theme.mixins.toolbar,
   content: {
     position: 'relative',
     flexGrow: 1,

--- a/dashboard/frontend/src/styles/colors.js
+++ b/dashboard/frontend/src/styles/colors.js
@@ -3,7 +3,7 @@ export default {
     greenDark: '#17703c',
     red: '#e74c3c',
     blue: '#3498db',
-    grey: '#666',
+    grey: '#ddd',
 
     ledText: 'yellow',
     ledTextWhite: 'white',

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -92,7 +92,6 @@ class IStateManager():
         Returns:
             int: Asset's status after power-off operation
         """
-        print('Graceful shutdown')
         self._sleep_shutdown()
         if self.status:
             self._set_state_off()
@@ -105,7 +104,6 @@ class IStateManager():
         Returns:
             int: Asset's status after power-off operation
         """
-        print("Powering down {}".format(self._asset_key))
         if self.status:
             self._set_state_off()
         return self.status
@@ -117,7 +115,6 @@ class IStateManager():
         Returns:
             int: Asset's status after power-on operation
         """
-        print("Powering up {}".format(self._asset_key))
         if self._parents_available() and not self.status:
             self._sleep_powerup()
             # udpate machine start time & turn on

--- a/enginecore/enginecore/state/state_managers.py
+++ b/enginecore/enginecore/state/state_managers.py
@@ -154,7 +154,7 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
                 db_s, int(self._asset_key), 'HighPrecOutputLoad'
             )
 
-            value_hp = (1000*(load*120)) / self.output_capacity
+            value_hp = abs((1000*(load*120)) / self.output_capacity)
 
             if oid_adv:
                 self._update_oid_value(oid_adv, dt_adv, snmp_data_types.Gauge32(value_hp/10))


### PR DESCRIPTION
When there're > 1 outlet (wall power sources) present, turning off one of the sockets & simulating complete power outage results in incorrect load distribution. 