### PR TITLE
Initial Playback Scenarios

### DIFF
--- a/dashboard/frontend/package-lock.json
+++ b/dashboard/frontend/package-lock.json
@@ -5548,7 +5548,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5963,7 +5964,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6019,6 +6021,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6062,12 +6065,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/dashboard/frontend/src/components/Navigation/SettingsOption.js
+++ b/dashboard/frontend/src/components/Navigation/SettingsOption.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { Settings } from "@material-ui/icons";
-import { IconButton, Divider, Drawer, List, ListItem, ListItemText } from '@material-ui/core';
+import { IconButton, Divider, Drawer, List, ListItem, ListItemText, } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
 /**
@@ -20,10 +20,19 @@ class SettingsOption extends React.Component {
 
   render() {
 
-    const { classes } = this.props;
+    const { classes, plays, executePlay, saveLayout } = this.props;
 
     const { drawerAnchor } = this.state;
     const drawerOpen = Boolean(drawerAnchor);
+
+    let playList = [];
+    for (const playName of plays) {
+      playList.push(
+        <ListItem button key={playName} onClick={() => executePlay(playName)}>
+          <ListItemText primary={playName} />
+        </ListItem>
+      );
+    }
 
     return (
       <Fragment>
@@ -54,12 +63,18 @@ class SettingsOption extends React.Component {
             >
               {/* Sidebar options */}
               <List>
-                <ListItem button onClick={this.props.saveLayout.bind(this)}>
+                <ListItem button onClick={saveLayout}>
                   <ListItemText primary="Save Layout" />
                 </ListItem>
                 <ListItem button onClick={()=>window.open('https://simengine.readthedocs.io/en/latest/')}>
                   <ListItemText primary="View Documentation" />
                 </ListItem>
+                {!!plays.length &&
+                  <ListItem key={'title'}>
+                    <h3>Scenarios</h3>
+                  </ListItem>
+                }
+                {playList}
               </List>
           </div>
         </Drawer>
@@ -78,6 +93,8 @@ const styles = theme => ({
 SettingsOption.propTypes = {
   classes: PropTypes.object, // styling
   saveLayout: PropTypes.func.isRequired, // drawer Save Layout callback
+  plays: PropTypes.array,
+  executePlay: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(SettingsOption);

--- a/dashboard/frontend/src/components/Navigation/TopNav.js
+++ b/dashboard/frontend/src/components/Navigation/TopNav.js
@@ -72,7 +72,11 @@ class TopNav extends React.Component {
             </Typography>
             {/* Gear openning a drawer */}
             <div className={classes.grow}>
-              <SettingsOption saveLayout={this.props.saveLayout}/>
+              <SettingsOption
+                saveLayout={this.props.saveLayout}
+                executePlay={this.props.executePlay}
+                plays={this.props.plays}
+              />
             </div>
 
             {/* Top-right nav options*/}
@@ -106,12 +110,22 @@ const styles = {
 };
 
 TopNav.propTypes = {
-  classes: PropTypes.object, // styling
-  saveLayout: PropTypes.func.isRequired, // drawer Save Layout callback
-  ambient: PropTypes.number.isRequired, // room temp
-  ambientRising: PropTypes.bool.isRequired, // is room temp going up?
-  mainsStatus: PropTypes.bool.isRequired, // mains power source status
+  /** styling */
+  classes: PropTypes.object,
+  /** current room temp */
+  ambient: PropTypes.number.isRequired,
+  /** indicates if room temp is going up */
+  ambientRising: PropTypes.bool.isRequired,
+  /** mains power source status */
+  mainsStatus: PropTypes.bool.isRequired,
+  /** collection of executable scripts */
+  plays: PropTypes.array,
+  /** mains toggle callback */
   togglePower: PropTypes.func.isRequired,
+  /** drawer Save Layout callback */
+  saveLayout: PropTypes.func.isRequired,
+  /** execute playbook callback */
+  executePlay: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(TopNav);

--- a/dashboard/frontend/src/components/socketClient.js
+++ b/dashboard/frontend/src/components/socketClient.js
@@ -2,7 +2,7 @@
 
 class simengineSocketClient {
 
-  constructor ({ onTopologyReceived, onAmbientReceived, onAssetReceived, onMainsReceived }) {
+  constructor (dataCallback) {
 
     // set up endpoint URL
     let newUri = '';
@@ -13,7 +13,7 @@ class simengineSocketClient {
     } else {
       newUri = "ws:";
     }
-    
+
     newUri += "//" + loc.hostname + ':8000/simengine';
 
     this.ws = new WebSocket(newUri);
@@ -21,18 +21,26 @@ class simengineSocketClient {
     this.ws.onmessage = ((evt) =>
     {
       const data = JSON.parse(evt.data);
-      
+
       console.log("Server sent data: ");
       console.log(data);
 
-      if (data.request === 'topology') {
-        onTopologyReceived(data.data);
-      } else if (data.request === 'ambient') {
-        onAmbientReceived(data.data);
-      } else if (data.request === 'asset') {
-        onAssetReceived(data.data);
-      } else if (data.request === 'mains') {
-        onMainsReceived(data.data);
+      switch(data.request) {
+        case 'topology':
+          dataCallback.onTopologyReceived(data.data);
+          break;
+        case 'ambient':
+          dataCallback.onAmbientReceived(data.data);
+          break;
+        case 'asset':
+          dataCallback.onAssetReceived(data.data);
+          break;
+        case 'mains':
+          dataCallback.onMainsReceived(data.data);
+          break;
+        case 'plays':
+          dataCallback.onPlaylistReceived(data.data);
+          break;
       }
     });
   }

--- a/enginecore/enginecore/cli/play.py
+++ b/enginecore/enginecore/cli/play.py
@@ -1,7 +1,17 @@
 """CLI endpoints for managing and executing playback related commands
 """
 import os 
-import enginecore.model.system_modeler as sys_modeler
+from enginecore.state.api import IStateManager
+
+
+def display_plays(plays):
+    """Show a list of available scenarios"""
+
+    show_scripts_of_type = lambda t, p: print('{}:\n {}'.format(t, '\n '.join(p)))
+
+    show_scripts_of_type('Bash Scripts', plays[0])
+    show_scripts_of_type('Python Scripts', plays[0])
+
 
 def play_command(power_group):
     """CLI endpoints for managing assets' power states & wallpower"""
@@ -13,5 +23,12 @@ def play_command(power_group):
     )
 
     folder_action.set_defaults(
-        func=lambda args: sys_modeler.set_play_path(os.path.abspath(args['path']))
+        func=lambda args: IStateManager.set_play_path(os.path.abspath(args['path']))
+    )
+
+    list_action = play_subp.add_parser('list', help="List scripts available for execution")
+
+
+    list_action.set_defaults(
+        func=lambda args: display_plays(IStateManager.plays())
     )

--- a/enginecore/enginecore/cli/play.py
+++ b/enginecore/enginecore/cli/play.py
@@ -30,7 +30,7 @@ def play_command(power_group):
 
     # cli actions/callbacks
     folder_action.set_defaults(
-        func=lambda args: IStateManager.set_play_path(os.path.abspath(args['path']))
+        func=lambda args: IStateManager.set_play_path(os.path.abspath(os.path.expanduser(args['path'])))
     )
 
     list_action.set_defaults(

--- a/enginecore/enginecore/cli/play.py
+++ b/enginecore/enginecore/cli/play.py
@@ -1,0 +1,17 @@
+"""CLI endpoints for managing and executing playback related commands
+"""
+import os 
+import enginecore.model.system_modeler as sys_modeler
+
+def play_command(power_group):
+    """CLI endpoints for managing assets' power states & wallpower"""
+    play_subp = power_group.add_subparsers()
+    
+    folder_action = play_subp.add_parser('folder', help="Update user-defined script folder")
+    folder_action.add_argument(
+        '-p', '--path', type=str, required=True, help="Path to the folder containing playback scripts"
+    )
+
+    folder_action.set_defaults(
+        func=lambda args: sys_modeler.set_play_path(os.path.abspath(args['path']))
+    )

--- a/enginecore/enginecore/cli/play.py
+++ b/enginecore/enginecore/cli/play.py
@@ -10,7 +10,7 @@ def display_plays(plays):
     show_scripts_of_type = lambda t, p: print('{}:\n {}'.format(t, '\n '.join(p)))
 
     show_scripts_of_type('Bash Scripts', plays[0])
-    show_scripts_of_type('Python Scripts', plays[0])
+    show_scripts_of_type('Python Scripts', plays[1])
 
 
 def play_command(power_group):
@@ -22,13 +22,21 @@ def play_command(power_group):
         '-p', '--path', type=str, required=True, help="Path to the folder containing playback scripts"
     )
 
+    list_action = play_subp.add_parser('list', help="List scripts available for execution")
+    exec_action = play_subp.add_parser('execute', help="Execute a specific script")
+    exec_action.add_argument(
+        '-p', '--play', type=str, required=True, help="Name of the play to be executed"
+    )
+
+    # cli actions/callbacks
     folder_action.set_defaults(
         func=lambda args: IStateManager.set_play_path(os.path.abspath(args['path']))
     )
 
-    list_action = play_subp.add_parser('list', help="List scripts available for execution")
-
-
     list_action.set_defaults(
         func=lambda args: display_plays(IStateManager.plays())
+    )
+
+    exec_action.set_defaults(
+        func=lambda args: IStateManager.execute_play(args['play']) # TODO: handle invalid play
     )

--- a/enginecore/enginecore/model/graph_reference.py
+++ b/enginecore/enginecore/model/graph_reference.py
@@ -912,7 +912,7 @@ class GraphReference():
     def get_psu_sensor_names(cls, session, server_key, psu_num):
         """Retrieve server-specific psu sensor names
         Args:
-            session:  database session
+            session: database session
             server_key(int): key of the server sensors belongs to
             psu_num(int): psu num
         """
@@ -936,3 +936,33 @@ class GraphReference():
             psu_names[entry['type']] = entry['name']
 
         return psu_names
+
+    @classmethod
+    def set_play_path(cls, session, path):
+        """Update path to the folder containing playbooks
+        Args:
+            session: database session
+            path(str): absolute path to the script folder
+        """
+        
+        session.run("MERGE (n:Playback { sref: 1 }) SET n.path=$path", path=path)
+
+
+    @classmethod
+    def get_play_path(cls, session):
+        """Get play folder
+        Args:
+            session: database session
+        Returns:
+            str: path to the plays/scripts
+        """
+        
+        results = session.run("MATCH (n:Playback { sref: 1 }) RETURN n.path as path")
+        record = results.single()
+        play_folder = ''
+
+        if record:
+            play_folder = record.get('path')
+
+        return play_folder
+    

--- a/enginecore/enginecore/model/system_modeler.py
+++ b/enginecore/enginecore/model/system_modeler.py
@@ -23,7 +23,7 @@ SIMENGINE_NODE_LABELS.extend(["Asset", "StageLayout", "SystemEnvironment", "EnvP
 SIMENGINE_NODE_LABELS.extend(["OID", "OIDDesc", "Sensor", "AddressSpace"])
 SIMENGINE_NODE_LABELS.extend(["CPU", "Battery"])
 SIMENGINE_NODE_LABELS.extend(["Controller", "Storcli", "BBU", "CacheVault", "VirtualDrive", "PhysicalDrive"])
-
+SIMENGINE_NODE_LABELS.extend(['Playback'])
 
 def _add_psu(key, psu_index, attr):
     """Add a PSU to an existing server
@@ -837,3 +837,12 @@ def delete_thermal_storage_target(attr):
 
     with GRAPH_REF.get_session() as session:
         session.run("\n".join(query))
+
+def set_play_path(path):
+    """Update path to the folder containing playbooks"""
+
+    with GRAPH_REF.get_session() as session:
+        session.run(
+            "MERGE (n:Playback { sref: 1 }) SET n.path=$path",
+            path=path
+        )

--- a/enginecore/enginecore/model/system_modeler.py
+++ b/enginecore/enginecore/model/system_modeler.py
@@ -837,12 +837,3 @@ def delete_thermal_storage_target(attr):
 
     with GRAPH_REF.get_session() as session:
         session.run("\n".join(query))
-
-def set_play_path(path):
-    """Update path to the folder containing playbooks"""
-
-    with GRAPH_REF.get_session() as session:
-        session.run(
-            "MERGE (n:Playback { sref: 1 }) SET n.path=$path",
-            path=path
-        )

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -426,6 +426,9 @@ class IStateManager():
         with graph_ref.get_session() as session:
 
             play_path = GraphReference.get_play_path(session)
+            if not play_path:
+                return ([], [])
+
             play_files = [f for f in os.listdir(play_path) if os.path.isfile(os.path.join(play_path, f))]
 
             return(
@@ -445,6 +448,9 @@ class IStateManager():
         with graph_ref.get_session() as session:
 
             play_path = GraphReference.get_play_path(session)
+            if not play_path:
+                return
+
             file_filter = lambda f: os.path.isfile(os.path.join(play_path, f)) and os.path.splitext(f)[0] == play_name
 
             play_file = [

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -406,6 +406,34 @@ class IStateManager():
 
 
     @classmethod
+    def set_play_path(cls, path):
+        """Update play folder containing scripts"""
+
+        graph_ref = GraphReference()
+        with graph_ref.get_session() as session: 
+            GraphReference.set_play_path(session, path)
+
+
+    @classmethod
+    def plays(cls):
+        """Get plays available for execution
+        Returns:
+            tuple: list of bash files as well as python scripts
+        """
+
+        graph_ref = GraphReference()
+        with graph_ref.get_session() as session:
+
+            play_path = GraphReference.get_play_path(session)
+            play_files = [f for f in os.listdir(play_path) if os.path.isfile(os.path.join(play_path, f))]
+
+            return(
+                [os.path.splitext(f)[0] for f in play_files if os.path.splitext(f)[1] != '.py'],
+                [os.path.splitext(f)[0] for f in play_files if os.path.splitext(f)[1] == '.py']
+            )
+
+
+    @classmethod
     def get_state_manager_by_key(cls, key, supported_assets):
         """Infer asset manager from key"""
 

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -2,6 +2,7 @@
 import time
 import os
 import tempfile
+import subprocess
 
 import redis
 
@@ -432,6 +433,7 @@ class IStateManager():
                 [os.path.splitext(f)[0] for f in play_files if os.path.splitext(f)[1] == '.py']
             )
 
+
     @classmethod
     def execute_play(cls, play_name):
         """Execute a specific play
@@ -449,7 +451,9 @@ class IStateManager():
                 f for f in os.listdir(play_path) if file_filter(f)
             ][0]
 
-            os.system(os.path.join(play_path, play_file))
+            subprocess.Popen(
+                os.path.join(play_path, play_file), stderr=subprocess.DEVNULL, close_fds=True
+            )
 
 
     @classmethod

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -432,6 +432,25 @@ class IStateManager():
                 [os.path.splitext(f)[0] for f in play_files if os.path.splitext(f)[1] == '.py']
             )
 
+    @classmethod
+    def execute_play(cls, play_name):
+        """Execute a specific play
+        Args:
+            play_name(str): playbook name
+        """
+
+        graph_ref = GraphReference()
+        with graph_ref.get_session() as session:
+
+            play_path = GraphReference.get_play_path(session)
+            file_filter = lambda f: os.path.isfile(os.path.join(play_path, f)) and os.path.splitext(f)[0] == play_name
+
+            play_file = [
+                f for f in os.listdir(play_path) if file_filter(f)
+            ][0]
+
+            os.system(os.path.join(play_path, play_file))
+
 
     @classmethod
     def get_state_manager_by_key(cls, key, supported_assets):

--- a/enginecore/simengine-cli
+++ b/enginecore/simengine-cli
@@ -13,6 +13,7 @@ from enginecore.cli.thermal import thermal_command
 from enginecore.cli.configure_state import configure_command
 from enginecore.cli.model import model_command
 from enginecore.cli.storage import storage_command
+from enginecore.cli.play import play_command
 
 
 ################ Define Command line options & arguments
@@ -42,6 +43,9 @@ configure_command(
 )
 model_command(
     subparsers.add_parser('model', help="Manage system model: create new/update existing asset etc.")
+)
+play_command(
+    subparsers.add_parser('play', help="Manage and execute playback scenarios")
 )
 
 try:


### PR DESCRIPTION
Fixes #39

`play` cli endpoints for playbook management & execution:
- set `play` folder (location of the play scripts, docs need to address `shebang` is required)
- list available plays (.py & bash scripts in the play folder)
- execute a specific play

plus UI drawer displaying a list of plays available for execution & launch scenario on nav item selection.