### PR TITLE
Save & Load actions support range arguments

### DIFF
--- a/enginecore/enginecore/cli/actions.py
+++ b/enginecore/enginecore/cli/actions.py
@@ -52,6 +52,17 @@ def range_args():
     return common_args
 
 
+def handle_file_command(args, client_request_func):
+    """Process file command (either save or load)
+    Args:
+        client_request_func(callable): StateClient method processing file command
+    """
+    client_request_func(
+        os.path.abspath(os.path.expanduser(args["filename"])),
+        slice(args["start"], args["end"]),
+    )
+
+
 def actions_command(actions_group):
     """Action command can be used to manage/replay recorded actions performed by SimEngine users"""
 
@@ -108,6 +119,7 @@ def actions_command(actions_group):
     load_action = play_subp.add_parser(
         "load",
         help="Load action history from a file (will override the existing actions)",
+        parents=[range_args()],
     )
 
     load_action.add_argument(
@@ -176,15 +188,10 @@ def actions_command(actions_group):
     dry_run_action.set_defaults(func=dry_run_actions)
 
     save_action.set_defaults(
-        func=lambda args: StateClient.save_actions(
-            os.path.abspath(os.path.expanduser(args["filename"])),
-            slice(args["start"], args["end"]),
-        )
+        func=lambda args: handle_file_command(args, StateClient.save_actions)
     )
     load_action.set_defaults(
-        func=lambda args: StateClient.load_actions(
-            os.path.abspath(os.path.expanduser(args["filename"]))
-        )
+        func=lambda args: handle_file_command(args, StateClient.load_actions)
     )
 
     rand_action.set_defaults(func=StateClient.rand_actions)

--- a/enginecore/enginecore/state/net/state_client.py
+++ b/enginecore/enginecore/state/net/state_client.py
@@ -197,13 +197,15 @@ class StateClient:
         )
 
     @classmethod
-    def load_actions(cls, filename: str):
+    def load_actions(cls, filename: str, slc: slice = slice(None, None)):
         """Request simengine to dynamically load actions from a filename
         Args:
             filename: .json file containing recorded action history
+            slc: load only this range of actions
         """
         StateClient.send_request(
-            ClientToServerRequests.load_actions, {"filename": filename}
+            ClientToServerRequests.load_actions,
+            {"filename": filename, "range": {"start": slc.start, "stop": slc.stop}},
         )
 
     @classmethod

--- a/enginecore/enginecore/state/net/ws_server.py
+++ b/enginecore/enginecore/state/net/ws_server.py
@@ -170,7 +170,10 @@ class WebSocket(Component):
     @handler(ClientToServerRequests.save_actions.name)
     def _handle_save_history_reqeust(self, details):
         """Save recorder history to a file"""
-        recorder.save_actions(action_file=details["payload"]["filename"])
+        recorder.save_actions(
+            action_file=details["payload"]["filename"],
+            slc=self._slice_from_paylaod(details),
+        )
 
     @handler(ClientToServerRequests.load_actions.name)
     def _handle_load_history_request(self, details):
@@ -178,6 +181,7 @@ class WebSocket(Component):
         recorder.load_actions(
             action_file=details["payload"]["filename"],
             map_key_to_state=IStateManager.get_state_manager_by_key,
+            slc=self._slice_from_paylaod(details),
         )
 
     @handler(ClientToServerRequests.set_recorder_status.name)

--- a/enginecore/enginecore/tools/recorder.py
+++ b/enginecore/enginecore/tools/recorder.py
@@ -24,26 +24,25 @@ class Recorder:
     def __call__(self, work: callable):
         """Make an instance of recorder a callable object that can be used as a decorator
         with functions/class methods.
+
         Function calls will be registered by the recorder & can be replayed later on.
 
         Example:
             recorder = Recorder()
             @recorder
-            def my_action():
+            def my_action(self):
                 ...
 
             each call to my_action() will be stored in action history of the recorder instance,
+        
+            *Note* that class or instance implementing recorded action must have key attribute
         """
 
         @functools.wraps(work)
         def record_wrapper(asset_self, *f_args, **f_kwargs):
 
             if asset_self.__module__.startswith(self._module) and self._enabled:
-                # full_work_args = inspect.getfullargspec(work).args
 
-                # if "self" in full_work_args or "cls" in full_work_args:
-                # else:
-                #     func_args = tuple((work,))
                 func_args = tuple((work, asset_self))
 
                 partial_func = functools.partial(*func_args, *f_args, **f_kwargs)
@@ -72,29 +71,43 @@ class Recorder:
         if not self.replaying:
             self._enabled = value
 
-    def save_actions(self, action_file: str = "/tmp/recorder_action_file.json"):
+    def save_actions(
+        self,
+        action_file: str = "/tmp/recorder_action_file.json",
+        slc: slice = slice(None, None),
+    ):
         """Save actions into a json file (actions can be later loaded)
         Args:
             action_file(optional): action history will be saved in this file
+            slc(optional): range of actions to be saved, defaults to all if not specified
         Example:
             Action history is saved in the following format:
             [
+                // for instance methods:
                 {
-                    "state": "..encoded base64 bytes..",
+                    "type": "ClassName",
+                    "key": integer key,
                     "args": "..encoded base64 bytes..",
                     "kwargs": "..encoded base64 bytes..",
                     "work": "method_name",
                     "timestamp": "utc-timestamp"
                 },
-                {...},
+                // for class methods:
+                {
+                    "type": "..encoded base64 bytes..",
+                    "args": "..encoded base64 bytes..",
+                    "kwargs": "..encoded base64 bytes..",
+                    "work": "method_name",
+                    "timestamp": "utc-timestamp"
+                },
                 {...}
             ]
-            Where "state" is the pickled IStateManager, "args" & "kwargs" 
+            Where "..encoded base64 bytes.." is codecs base64 encoded pickled python object
         """
         serialized_actions = []
         json_pickle = lambda x: codecs.encode(pickle.dumps(x), "base64").decode()
 
-        for action in self._actions:
+        for action in self._actions[slc]:
 
             action_info = {
                 "args": json_pickle(action["work"].args[1:]),
@@ -115,9 +128,19 @@ class Recorder:
             json.dump(serialized_actions, action_f_handler, indent=2)
 
     def load_actions(
-        self, map_key_to_state, action_file: str = "/tmp/recorder_action_file.json"
+        self,
+        map_key_to_state: callable,
+        action_file: str = "/tmp/recorder_action_file.json",
+        slc=slice(None, None),
     ):
-        """load actions from a file"""
+        """load action history from a file; Note that this function clears existing actions
+        Args:
+            map_key_to_state: instances are not serialized instead their keys are stored in the file;
+                              the de-serialization is key-based and must be provided with this argument
+                              by mapping keys to python objects
+            action_file(optional): action history will be saved in this file
+            slc(optional): range of actions to be loaded from a file, defaults to all if not specified
+        """
 
         if self._replaying:
             logging.warning("Cannot load actions while replaying")
@@ -129,7 +152,7 @@ class Recorder:
         with open(action_file, "r") as action_f_handler:
             serialized_actions = json.load(action_f_handler)
 
-        for action in serialized_actions:
+        for action in serialized_actions[slc]:
             if "key" in action:
                 state = map_key_to_state(action["key"])
             else:

--- a/enginecore/tests/test_recorder.py
+++ b/enginecore/tests/test_recorder.py
@@ -179,6 +179,49 @@ class RecorderTests(unittest.TestCase):
         action_details = new_recorder.get_action_details()
         self.assertEqual(4, len(action_details))
 
+    def test_serialization_save_range(self):
+        """Test action saving but only slice of action history"""
+        self.recorded_entity_1.double_a()  # 4
+        self.recorded_entity_1.double_a()  # 8
+        self.recorded_entity_1.double_a()  # 16
+
+        # serialize only the last action
+        REC.save_actions(
+            action_file="/tmp/simengine_rec_utest.json", slc=slice(-1, None)
+        )
+
+        new_recorder = Recorder(module=__name__)
+        new_recorder.load_actions(
+            map_key_to_state=RecordedEntity, action_file="/tmp/simengine_rec_utest.json"
+        )
+
+        new_recorder.replay_all()
+        self.assertEqual(32, RecordedEntity.test_a["value"])
+        action_details = new_recorder.get_action_details()
+        self.assertEqual(1, len(action_details))
+
+    def test_serialization_load_range(self):
+        """Test action loading but only slice of action history"""
+
+        self.recorded_entity_1.double_a()  # 4
+        self.recorded_entity_1.double_a()  # 8
+        self.recorded_entity_1.double_a()  # 16
+
+        # serialize only the last action
+        REC.save_actions(action_file="/tmp/simengine_rec_utest.json")
+
+        new_recorder = Recorder(module=__name__)
+        new_recorder.load_actions(
+            map_key_to_state=RecordedEntity,
+            action_file="/tmp/simengine_rec_utest.json",
+            slc=slice(-1, None),
+        )
+
+        new_recorder.replay_all()
+        self.assertEqual(32, RecordedEntity.test_a["value"])
+        action_details = new_recorder.get_action_details()
+        self.assertEqual(1, len(action_details))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #60 

This allows users to (optionally) load and save only a slice of action history with CLI args.

For example, save command in this case will serialise only last 3 power up actions

```bash
$ simengine-cli actions list
0) [2019-04-02 17:09:18] IStaticDeviceManager(62).shut_down()
1) [2019-04-02 17:09:19] IStaticDeviceManager(63).shut_down()
2) [2019-04-02 17:09:21] IStaticDeviceManager(61).power_up()
3) [2019-04-02 17:09:22] IStaticDeviceManager(62).power_up()
4) [2019-04-02 17:09:24] IStaticDeviceManager(63).power_up()
$ simengine-cli actions save --start=-3 --filename="/tmp/test.json"

```