### PR TITLE
Date range for action commands

### DIFF
--- a/docs/Asset Management.md
+++ b/docs/Asset Management.md
@@ -333,9 +333,20 @@ $ simengine-cli actions replay --list --start=2 --end=4
 Replay only the last recorded action:
 
 ```bash
-  $ simengine-cli actions replay --list --start=-1
-  5) [2019-04-02 11:06:29] IStaticDeviceManager(63).power_up()
+$ simengine-cli actions replay --list --start=-1
+5) [2019-04-02 11:06:29] IStaticDeviceManager(63).power_up()
 ```
+
+Replay actions that occured today between "11:06:22" and "11:06:27"
+
+```bash
+$ simengine-cli actions replay --list --start="11:06:22" --end="11:06:27"
+1) [2019-04-02 11:06:22] IStaticDeviceManager(62).shut_down()
+2) [2019-04-02 11:06:24] IStaticDeviceManager(63).shut_down()
+3) [2019-04-02 11:06:25] IStaticDeviceManager(61).power_up()
+4) [2019-04-02 11:06:27] IStaticDeviceManager(62).power_up()
+```
+
 
 **Recorder Status**
 

--- a/enginecore/enginecore/cli/actions.py
+++ b/enginecore/enginecore/cli/actions.py
@@ -119,11 +119,15 @@ def range_args():
     common_args = argparse.ArgumentParser(add_help=False)
 
     common_args.add_argument(
-        "-s", "--start", help="Starting at this action number (range specifier)"
+        "-s",
+        "--start",
+        help="Starting at this action number, or at this time today (format %H:%M:%S) or date (%Y-%m-%d %H:%M:%S)",
     )
 
     common_args.add_argument(
-        "-e", "--end", help="Ending at this action number (range specifier)"
+        "-e",
+        "--end",
+        help="Ending at this action number, or at this time today (format %H:%M:%S) or date (%Y-%m-%d %H:%M:%S)",
     )
 
     return common_args

--- a/enginecore/enginecore/cli/actions.py
+++ b/enginecore/enginecore/cli/actions.py
@@ -54,19 +54,26 @@ def get_date_from_str(date_str):
 
 
 def get_index_from_range_opt(range_opt, actions, start_opt=True):
-    """Analyze range option"""
+    """Analyze range option, find index for rand_opt if it is a date string
+    Args:
+        rand_opt: either index of an action or date string in format 
+                  "%H:%M:%S" or "%Y-%m-%d %H:%M:%S"
+        actions(list): list of action history
+        start_opt: indicates if the index provided is the starting point of a slice
+    Returns:
+        int: index of the starting or ending action
+    """
 
-    # action index was provided
+    # action index was provided - return number
     if range_opt is None or range_opt.isdigit():
         return int(range_opt) if range_opt else None
 
+    # try to parse a date
     range_date = get_date_from_str(range_opt)
-
-    # could not parse the date format
     if not range_date:
         return None
 
-    # find actions within the date
+    # find actions within the date range
     filter_actions_by_date = lambda d, op: list(
         filter(lambda x: op(dt.fromtimestamp(x["timestamp"]), d), actions)
     )
@@ -89,12 +96,19 @@ def get_index_from_range_opt(range_opt, actions, start_opt=True):
 
 
 def get_action_slice(start, end):
-    """Parse start & end range specifiers"""
+    """Parse start & end range specifiers
+    Args:
+        start: start index or starting datestring or time string in a format "%H:%M:%S" or "%Y-%m-%d %H:%M:%S"
+        end: end index or end date/time in a format "%H:%M:%S" or "%Y-%m-%d %H:%M:%S"
+    Returns:
+        slice: range of actions
+    """
 
     try:
         return slice(int(start), int(end))
     except (ValueError, TypeError):
 
+        # attemp to parse dates if one/both of the range options are non digits
         all_actions = StateClient.list_actions(slice(None, None))
 
         start = get_index_from_range_opt(start, all_actions)


### PR DESCRIPTION
Resolves #55 

Example of a date in an action query:

```
$ simengine-cli actions list --start="2019-04-11 17:35:38" --end="09:37:38"
8) [2019-04-11 17:35:38] IStaticDeviceManager(65).power_up()
9) [2019-04-11 17:35:39] IBMCServerStateManager(5).set_physical_drive_prop(0, 11, {'media_error_count': 2, 'State': None})
10) [2019-04-12 09:37:36] IOutletStateManager(35).power_off()
11) [2019-04-12 09:37:37] ISystemEnvironment(0).power_outage()
12) [2019-04-12 09:37:38] IOutletStateManager(46).power_off()
```

`--start` and `--end` can either be indices of action history items, full dates in a format "%Y-%m-%d %H:%M:%S" or today's time as "%H:%M:%S"