### PR TITLE
IPMI sim Supports Lan Get Commands

### DIFF
--- a/enginecore/enginecore/cli/model.py
+++ b/enginecore/enginecore/cli/model.py
@@ -407,6 +407,13 @@ def create_command(create_asset_group):
     create_server_bmc_action.add_argument(
         "--port", type=int, default=9001, help="IPMI interface port"
     )
+
+    create_server_bmc_action.add_argument(
+        "--interface",
+        type=str,
+        default="",
+        help="Network interface attached to the server",
+    )
     create_server_bmc_action.add_argument(
         "--vmport",
         type=int,

--- a/enginecore/enginecore/model/system_modeler.py
+++ b/enginecore/enginecore/model/system_modeler.py
@@ -196,6 +196,7 @@ IPMI_LAN_DEFAULTS = {
     "user": "ipmiusr",
     "password": "test",
     "host": "localhost",
+    "interface": "",
     "port": 9001,
     "vmport": 9002,
     "storcli_port": 50000,

--- a/enginecore/enginecore/state/agent/ipmi_agent.py
+++ b/enginecore/enginecore/state/agent/ipmi_agent.py
@@ -25,6 +25,7 @@ class IPMIAgent(Agent):
         "port",
         "user",
         "password",
+        "interface",
         "vmport",
         "num_components",
     ]
@@ -74,6 +75,9 @@ class IPMIAgent(Agent):
         lan_conf_opt = {
             "asset_key": self._sensor_repo.server_key,
             "extend_lib": self.extend_plugin_path,
+            "lan_path": os.path.join(
+                os.environ["SIMENGINE_IPMI_TEMPL"], "ipmi_sim_lancontrol"
+            ),
             **self._ipmi_config,
         }
 

--- a/enginecore/ipmi_template/ipmi_sim_lancontrol
+++ b/enginecore/ipmi_template/ipmi_sim_lancontrol
@@ -82,7 +82,7 @@ do_get() {
 		;;
 
 	    subnet_mask)
-		val=``# `/sbin/ifconfig $device | awk '/netmask /{ print $4;} '`
+		val=`/sbin/ifconfig $device | awk '/netmask /{ print $4;} '`
 		if [ "x$val" = "x" ]; then
 		    val="255.255.0.0"
 		fi

--- a/enginecore/ipmi_template/ipmi_sim_lancontrol
+++ b/enginecore/ipmi_template/ipmi_sim_lancontrol
@@ -55,7 +55,7 @@ do_get() {
     while [ "x$1" != "x" ]; do
 	case $1 in
 	    ip_addr)
-		val=`ifconfig $device | grep '^ *inet addr:' | tr ':' ' ' | sed 's/.*inet addr \([0-9.]*\).*$/\1/'`
+		val=`ifconfig $device | grep 'inet' | awk '{print $2}'`
 		if [ "x$val" = "x" ]; then
 		    val="0.0.0.0"
 		fi
@@ -69,29 +69,29 @@ do_get() {
 		    xdhcp)
 			;;
 		    *)
-			val="unknown"
+			val="static"
 			;;
 		esac
 		;;
 
 	    mac_addr)
-		val=`ifconfig $device | grep 'HWaddr' | sed 's/.*HWaddr \([0-9a-f:]*\).*$/\1/'`
+		val=`ifconfig $device | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'`
 		if [ "x$val" = "x" ]; then
 		    val="00:00:00:00:00:00"
 		fi
 		;;
 
 	    subnet_mask)
-		val=`ifconfig $device | grep '^ *inet addr:' | tr ':' ' ' | sed 's/.*Mask \([0-9.]*\).*$/\1/'`
+		val=``# `/sbin/ifconfig $device | awk '/netmask /{ print $4;} '`
 		if [ "x$val" = "x" ]; then
-		    val="0.0.0.0"
+		    val="255.255.0.0"
 		fi
 		;;
 
 	    default_gw_ip_addr)
-		val=`route -n | grep '^0\.0\.0\.0' | grep 'eth1$' | tr ' ' '\t' | tr -s '\t' '\t' | cut -f 2`
+		val=`route -n | grep '^0\.0\.0\.0' | grep "$device" | tr ' ' '\t' | tr -s '\t' '\t' | cut -f 2`
 		if [ "x$val" = "x" ]; then
-		    val="0.0.0.0"
+		    val="10.20.255.254"
 		fi
 		;;
 

--- a/enginecore/ipmi_template/lan.conf
+++ b/enginecore/ipmi_template/lan.conf
@@ -39,7 +39,7 @@ set_working_mc 0x20
 
     # A program to get and set the LAN configuration of the interface.
     #lan_config_program "/usr/local/bin/ipmi_sim_lancontrol eth0"
-    lan_config_program "/usr/local/bin/ipmi_sim_lancontrol bcn1_bridge1"
+    lan_config_program "$lan_path $interface"
   endlan
 
   #chassis_control "./ipmi_sim_chassiscontrol 0x20"


### PR DESCRIPTION
Fixes #86 

This results in Striker Dashboard completing IPMI LAN setup stage of the installation process.
  
Note that we only support query for ipmi LAN configurations like:
```
$ ipmitool lan print 1
``` 

IPMI sim will ignore any set commands e.g. 
```
$ ipmitool lan set 2 ipaddr 10.20.51.1
```

If necessary, any network configurations can be done on the host before the installation, with commands such as:
```
ifconfig bcn1_bridge1:1 10.20.51.1/16
ifconfig bcn1_bridge1:1 netmask 255.255.0.0
``` 