### PR TITLE
Anvil Set-Up documentation 

### DIFF
--- a/data/an-a01n01.xml
+++ b/data/an-a01n01.xml
@@ -1,0 +1,230 @@
+<domain type='kvm' id='701' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>an-a01n01</name>
+  <uuid>0d024d9b-b7b1-4f1f-b38c-bd298e3e0685</uuid>
+  <memory unit='KiB'>8388608</memory>
+  <currentMemory unit='KiB'>8388608</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.11'>hvm</type>
+    <bootmenu enable='yes'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+  </features>
+  <cpu mode='custom' match='exact' check='full'>
+    <model fallback='forbid'>Skylake-Client-IBRS</model>
+    <vendor>Intel</vendor>
+    <feature policy='require' name='ss'/>
+    <feature policy='require' name='vmx'/>
+    <feature policy='require' name='hypervisor'/>
+    <feature policy='require' name='tsc_adjust'/>
+    <feature policy='require' name='md-clear'/>
+    <feature policy='require' name='ssbd'/>
+    <feature policy='require' name='pdpe1gb'/>
+    <feature policy='disable' name='mpx'/>
+    <feature policy='disable' name='xsavec'/>
+    <feature policy='disable' name='xgetbv1'/>
+  </cpu>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-kvm</emulator>
+    <disk type='file' device='cdrom'>
+      <target dev='hda' bus='ide'/>
+      <readonly/>
+      <alias name='ide0-0-0'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/an-a01n01-1.qcow2'/>
+      <backingStore/>
+      <target dev='vda' bus='virtio'/>
+      <boot order='1'/>
+      <alias name='virtio-disk0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='ich9-ehci1'>
+      <alias name='usb'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x7'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci1'>
+      <alias name='usb'/>
+      <master startport='0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci2'>
+      <alias name='usb'/>
+      <master startport='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci3'>
+      <alias name='usb'/>
+      <master startport='4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'>
+      <alias name='pci.0'/>
+    </controller>
+    <controller type='ide' index='0'>
+      <alias name='ide'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:54:e9:8d'/>
+      <source network='default' bridge='virbr0'/>
+      <target dev='vnet0'/>
+      <model type='e1000'/>
+      <alias name='net0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:e1:2c:35'/>
+      <source network='default' bridge='virbr0'/>
+      <target dev='vnet1'/>
+      <model type='e1000'/>
+      <alias name='net1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0a' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:78:1a:3c'/>
+      <source network='sn1_bridge1' bridge='sn1_bridge1'/>
+      <target dev='vnet2'/>
+      <model type='e1000'/>
+      <alias name='net2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0b' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:ad:02:61'/>
+      <source network='sn1_bridge1' bridge='sn1_bridge1'/>
+      <target dev='vnet3'/>
+      <model type='e1000'/>
+      <alias name='net3'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0c' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:2d:8d:7a'/>
+      <source network='bcn1_bridge1' bridge='bcn1_bridge1'/>
+      <target dev='vnet4'/>
+      <model type='e1000'/>
+      <alias name='net4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0d' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:1e:b8:23'/>
+      <source network='bcn1_bridge1' bridge='bcn1_bridge1'/>
+      <target dev='vnet5'/>
+      <model type='e1000'/>
+      <boot order='2'/>
+      <alias name='net5'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0e' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <source path='/dev/pts/2'/>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/2'>
+      <source path='/dev/pts/2'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <channel type='unix'>
+      <source mode='bind' path='/var/lib/libvirt/qemu/channel/target/domain-701-an-a01n01/org.qemu.guest_agent.0'/>
+      <target type='virtio' name='org.qemu.guest_agent.0' state='disconnected'/>
+      <alias name='channel0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0' state='disconnected'/>
+      <alias name='channel1'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <alias name='input0'/>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'>
+      <alias name='input1'/>
+    </input>
+    <input type='keyboard' bus='ps2'>
+      <alias name='input2'/>
+    </input>
+    <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <alias name='sound0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <alias name='video0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir0'/>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir1'/>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <alias name='rng0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+    </rng>
+  </devices>
+  <seclabel type='dynamic' model='selinux' relabel='yes'>
+    <label>system_u:system_r:svirt_t:s0:c598,c852</label>
+    <imagelabel>system_u:object_r:svirt_image_t:s0:c598,c852</imagelabel>
+  </seclabel>
+  <seclabel type='dynamic' model='dac' relabel='yes'>
+    <label>+107:+107</label>
+    <imagelabel>+107:+107</imagelabel>
+  </seclabel>
+  <qemu:commandline>
+    <qemu:arg value='-chardev'/>
+    <qemu:arg value='socket,id=ipmi0,host=127.0.0.1,port=9002,reconnect=2'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='ipmi-bmc-extern,id=bmc0,chardev=ipmi0'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='isa-ipmi-bt,bmc=bmc0'/>
+    <qemu:arg value='-serial'/>
+    <qemu:arg value='mon:tcp::9012,server,telnet,nowait'/>
+    <qemu:arg value='-chardev'/>
+    <qemu:arg value='socket,id=simengine-storage-tcp,host=localhost,port=50000,reconnect=2'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='virtio-serial'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='virtserialport,chardev=simengine-storage-tcp,name=systems.cdot.simengine.storage.net'/>
+  </qemu:commandline>
+</domain>
+

--- a/data/an-a01n02.xml
+++ b/data/an-a01n02.xml
@@ -1,0 +1,168 @@
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>an-a01n02</name>
+  <uuid>c68617af-1bb6-4557-b0a5-c219fbc0cca7</uuid>
+  <memory unit='KiB'>8388608</memory>
+  <currentMemory unit='KiB'>8388608</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.11'>hvm</type>
+    <bootmenu enable='yes'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+  </features>
+  <cpu mode='host-model' check='partial'>
+    <model fallback='allow'/>
+  </cpu>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-kvm</emulator>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <target dev='hda' bus='ide'/>
+      <readonly/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/an-a01n02-1.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <boot order='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='ich9-ehci1'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x7'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci1'>
+      <master startport='0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci2'>
+      <master startport='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci3'>
+      <master startport='4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:fe:c8:4c'/>
+      <source network='default'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:ba:35:33'/>
+      <source network='default'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0a' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:3f:f7:ac'/>
+      <source network='sn1_bridge1'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0b' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:36:df:00'/>
+      <source network='sn1_bridge1'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0c' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:fd:d9:3e'/>
+      <source network='bcn1_bridge1'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0d' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:91:4e:99'/>
+      <source network='bcn1_bridge1'/>
+      <model type='e1000'/>
+      <boot order='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0e' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+    </rng>
+  </devices>
+  <qemu:commandline>
+    <qemu:arg value='-chardev'/>
+    <qemu:arg value='socket,id=ipmi0,host=127.0.0.1,port=9102,reconnect=2'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='ipmi-bmc-extern,id=bmc0,chardev=ipmi0'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='isa-ipmi-bt,bmc=bmc0'/>
+    <qemu:arg value='-serial'/>
+    <qemu:arg value='mon:tcp::9012,server,telnet,nowait'/>
+    <qemu:arg value='-chardev'/>
+    <qemu:arg value='socket,id=simengine-storage-tcp,host=localhost,port=50001,reconnect=10'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='virtio-serial'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='virtserialport,chardev=simengine-storage-tcp,name=systems.cdot.simengine.storage.net'/>
+  </qemu:commandline>
+</domain>
+

--- a/data/an-striker01.xml
+++ b/data/an-striker01.xml
@@ -1,0 +1,129 @@
+<domain type='kvm'>
+  <name>an-striker01</name>
+  <uuid>39e6f8aa-9c10-46a5-a7a4-9d6334543b08</uuid>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.11'>hvm</type>
+    <bootmenu enable='yes'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+  </features>
+  <cpu mode='host-model' check='partial'>
+    <model fallback='allow'/>
+  </cpu>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-kvm</emulator>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='/var/lib/libvirt/images/Anvil_m2-v2.0.7_CentOS-6.10.iso'/>
+      <target dev='hda' bus='ide'/>
+      <readonly/>
+      <boot order='2'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/an-striker01-1.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <boot order='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='ich9-ehci1'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x7'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci1'>
+      <master startport='0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci2'>
+      <master startport='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci3'>
+      <master startport='4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:cd:02:b6'/>
+      <source network='default'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:de:45:76'/>
+      <source network='bcn1_bridge1'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0a' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+    </rng>
+  </devices>
+</domain>
+

--- a/data/an-striker02.xml
+++ b/data/an-striker02.xml
@@ -1,0 +1,128 @@
+<domain type='kvm'>
+  <name>an-striker02</name>
+  <uuid>f7872df2-ac12-4cfa-8d1c-9f773035da19</uuid>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.11'>hvm</type>
+    <bootmenu enable='yes'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+  </features>
+  <cpu mode='host-model' check='partial'>
+    <model fallback='allow'/>
+  </cpu>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-kvm</emulator>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <target dev='hda' bus='ide'/>
+      <readonly/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/an-striker02-2.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <boot order='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='ich9-ehci1'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x7'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci1'>
+      <master startport='0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci2'>
+      <master startport='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci3'>
+      <master startport='4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:4e:de:2a'/>
+      <source network='default'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <interface type='network'>
+      <mac address='52:54:00:9e:62:a7'/>
+      <source network='bcn1_bridge1'/>
+      <model type='e1000'/>
+      <boot order='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0a' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+    </rng>
+  </devices>
+</domain>
+

--- a/docs/Anvil Model.md
+++ b/docs/Anvil Model.md
@@ -46,7 +46,7 @@ We will need to allocate IP addresses for the SNMP simulators on the host machin
     You may need to re-configure your firewall and expose port 161 (SNMP) as well as port 623 (IPMI) to the striker systems.
 
 !!! note
-    Network assignment will be lost on system reboot
+    Network assignment will be lost on system reboot, make sure to run the script on system start
 
 ## VM
 
@@ -60,7 +60,7 @@ We will need to allocate IP addresses for the SNMP simulators on the host machin
     -     an-striker01                   shut off
     -     an-striker02                   shut off
 
-The installation of the VMs plus minor setup need to be performed prior to the system modelling stage.
+The installation of the VMs plus minor setup need to be performed prior to the system modelling stage. You can use the official 'anvil-generate-iso' tool to create striker dashboards (see [An!Wiki page](https://www.alteeve.com/w/Build_the_Anvil!_m2_Install_Media) for more details).
 
 **Resources**
 
@@ -204,9 +204,10 @@ simengine-cli model power-link -s61 -d71 # [an-pdu02]={port-1}=>{psu-1}=>[an-a01
 simengine-cli model power-link -s62 -d81 # [an-pdu02]={port-2}=>{psu-1}=>[an-a01n02]
 
 # Power Up Striker Servers
-simengine-cli model power-link -s58 -d91 # [an-pdu01]={port-1}=>{psu-2}=>[an-a01n01]
-simengine-cli model power-link -s68 -d101 # [an-pdu02]={port-1}=>{psu-1}=>[an-a01n01]
+simengine-cli model power-link -s58 -d91  # [an-pdu01]={port-8}=>{psu-1}=>[an-striker01]
+simengine-cli model power-link -s68 -d101 # [an-pdu02]={port-8}=>{psu-1}=>[an-striker02]
 ```
+
 Re-start the daemon:
 `sudo systemctl start simengine-core`
 
@@ -228,27 +229,31 @@ You can customize the layout by positioning the assets in the preferred way. Cli
 
 ## Management
 
+Make sure all 6 hardware assets (2 UPSes, 2 PDUs and 2 Anvil Nodes) are reachable from the striker servers `an-striker01` and `an-striker01` prior to launching installation step with the striker dashboard. Double check your firewall rules if both `snmpsimd` and `ipmi_sim` processes are running but network interfaces appear unavailable.
+
+Once this step is completed, you can proceed to [building anvil cluster](https://www.alteeve.com/w/Build_an_m2_Anvil!).
+
 **UPS**
 
-UPSes’ SNMP interface can be reached at `192.168.124.3` & `192.168.124.4`
+UPSes’ SNMP interface can be reached at `10.20.3.1` & `10.20.3.2`
 
 For example:
 
-`snmpwalk -Cc -c public -v 1 192.168.124.3 .1.3.6.1.4.1.318.1.1.1.2.2`
+`snmpwalk -Cc -c public -v 1 10.20.3.1 .1.3.6.1.4.1.318.1.1.1.2.2`
 
-`snmpwalk -Cc -c public -v 1 192.168.124.4 .1.3.6.1.4.1.318.1.1.1.2.2`
+`snmpwalk -Cc -c public -v 1 10.20.3.2 .1.3.6.1.4.1.318.1.1.1.2.2`
 
 More documentation on UPS management can be found here: [link](https://simengine.readthedocs.io/en/latest/AssetsConfigurations/#ups);
 
 **PDU**
 
-PDUs SNMP interface is accessible at `192.168.124.5` & `192.168.124.6`
+PDUs SNMP interface is accessible at `10.20.2.1` & `10.20.2.2`
 
 For example:
 
-`snmpwalk -Cc -c public -v 1 192.168.124.5`
+`snmpwalk -Cc -c public -v 1 10.20.2.1`
 
-`snmpwalk -Cc -c public -v 1 192.168.124.6`
+`snmpwalk -Cc -c public -v 1 10.20.2.2`
 
 **Server-BMC**
 
@@ -256,11 +261,11 @@ Servers that support BMC interface can be accessed from both host machine & the 
 
 Running from host example:
 
-`ipmitool -H localhost -p 9001 -U ipmiusr -P test sdr list # server 7 (an-a01n01)`
+`ipmitool -H 10.20.11.1 -U ipmiusr -P test sdr list # server 7 (an-a01n01)`
 
-`ipmitool -H localhost -p 9101 -U ipmiusr -P test sdr list # server 8 (an-a01n02)`
+`ipmitool -H 10.20.11.2 -U ipmiusr -P test sdr list # server 8 (an-a01n02)`
 
-VM:
+Or inside anvil VMs:
 
 `sudo ipmitool sdr list`
 

--- a/docs/Anvil Model.md
+++ b/docs/Anvil Model.md
@@ -43,11 +43,15 @@ The installation of the VMs plus minor setup need to be performed prior to the s
 For hardware resources, it is recommended to allocate:
 
 Memory:
+
 - `8192 MiB` per each `an-a01n0x` node
+
 - `1024 MiB` per each `an-striker0x` control server
 
 Storage:
+
 - `100 Gib` per each `an-a01n0x` node
+
 - `50 Gib` per each `an-striker0x` control server
 
 

--- a/docs/Anvil Model.md
+++ b/docs/Anvil Model.md
@@ -4,18 +4,18 @@ Simengine can support various topology layouts; In this section we will attempt 
 
 This table summarises the general layout of the `simengine` system model we are going to configure:
 
-| **key** | **Name**     | **Type**   | **Interface**                                        |
-| ------- | ------------ | ---------- | ---------------------------------------------------- |
-| 1       | outlet-1     | outlet     |                                                      |
-| 2       | outlet-2     | outlet     |                                                      |
-| 3       | ups01        | ups        | SNMP → reachable at 192.168.124.3 (default port 161) |
-| 4       | ups02        | ups        | SNMP → reachable at 192.168.124.4                    |
-| 5       | pdu01        | pdu        | SNMP → reachable at 192.168.124.5                    |
-| 6       | pdu02        | pdu        | SNMP → reachable at 192.168.124.6                    |
-| 7       | an-a01n01    | server-bmc | IPMI → reachable at localhost:9001 (or from the VM)  |
-| 8       | an-a01n02    | server-bmc | IPMI → reachable at localhost:9101 (or from the VM)  |
-| 9       | an-striker01 | server     |                                                      |
-| 10      | an-striker02 | server     |                                                      |
+| **key** | **Name**     | **Type**   | **Address**                                          | **Interface**  |
+| ------- | ------------ | ---------- | ---------------------------------------------------- | -------------- |
+| 1       | outlet-1     | outlet     |                                                      |                |
+| 2       | outlet-2     | outlet     |                                                      |                |
+| 3       | ups01        | ups        | SNMP → reachable at 10.20.3.1 (default port 161)     | bcn1_bridge1:1 |
+| 4       | ups02        | ups        | SNMP → reachable at 10.20.3.2                        | bcn1_bridge1:2 |
+| 5       | pdu01        | pdu        | SNMP → reachable at 10.20.2.1                        | bcn1_bridge1:3 |
+| 6       | pdu02        | pdu        | SNMP → reachable at 10.20.2.2                        | bcn1_bridge1:4 |
+| 7       | an-a01n01    | server-bmc | IPMI → reachable at 10.20.11.1 (or from the VM)      | bcn1_bridge1:5 |
+| 8       | an-a01n02    | server-bmc | IPMI → reachable at 10.20.11.2 (or from the VM)      | bcn1_bridge1:6 |
+| 9       | an-striker01 | server     |                                                      |                |
+| 10      | an-striker02 | server     |                                                      |                |
 
 4 VMs will be running so the host machine should preferably have more than 4 cores.
 
@@ -29,7 +29,7 @@ We will need to allocate IP addresses for the SNMP simulators on the host machin
     sudo ip addr add dev enp4s0 192.168.124.6/24 # PDU 2
 
 !!! note
-    You may need to re-configure your firewall and expose port 161 to the striker systems.
+    You may need to re-configure your firewall and expose port 161 (SNMP) as well as port 623 (IPMI) to the striker systems.
 
 ## VM
 

--- a/docs/Anvil Model.md
+++ b/docs/Anvil Model.md
@@ -17,7 +17,7 @@ This table summarises the general layout of the `simengine` system model we are 
 | 9       | an-striker01 | server     |                                                      |                |
 | 10      | an-striker02 | server     |                                                      |                |
 
-4 VMs will be running so the host machine should preferably have more than 4 cores.
+4 VMs will be running so the host machine should preferably have more than 4 cores (ideally, `500GB` available disk space, `8` CPU cores and `32GB` memory).
 
 ## Network Configuration
 
@@ -44,6 +44,13 @@ We will need to allocate IP addresses for the SNMP simulators on the host machin
     -     an-striker02                   shut off
 
 The installation of the VMs plus minor setup need to be performed prior to the system modelling stage.
+
+For hardware resources, it is recommended to have:
+- `8192 MiB` per each `an-a01n0x` node
+- `100 Gib` per each `an-a01n0x` node
+- `1024 MiB` per each `an-striker0x` control server
+- `50 Gib` per each `an-striker0x` control server
+
 
 ### BMC and storcli64
 

--- a/enginecore/script/bridges
+++ b/enginecore/script/bridges
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+cat > /tmp/bcn1.xml << EOF
+<network>
+  <name>bcn1_bridge1</name>
+  <uuid>5b7605d0-6ec5-4530-b28e-86b681c07801</uuid>
+  <bridge name='bcn1_bridge1' stp='on' delay='0'/>
+  <mac address='52:54:00:bc:cc:6f'/>
+  <domain name='bcn1_bridge1'/>
+</network>
+EOF
+
+cat > /tmp/bcn2.xml << EOF
+<network>
+  <name>bcn2_bridge1</name>
+  <uuid>ba8cf0bf-d69c-44b2-8f60-72ef66448035</uuid>
+  <bridge name='bcn2_bridge1' stp='on' delay='0'/>
+  <mac address='52:54:00:bc:dd:6f'/>
+  <domain name='bcn2_bridge1'/>
+</network>
+EOF
+
+cat > /tmp/sn1.xml << EOF
+<network>
+  <name>sn1_bridge1</name>
+  <uuid>4a46283d-b7ac-4e75-9c90-5bee35ed6bf8</uuid>
+  <bridge name='sn1_bridge1' stp='on' delay='0'/>
+  <mac address='52:54:00:9c:26:b8'/>
+  <domain name='sn1_bridge1'/>
+</network>
+EOF
+
+cat > /tmp/sn2.xml << EOF
+<network>
+  <name>sn2_bridge1</name>
+  <uuid>713799c7-fcc4-46f6-b4c8-fbe9d9605edd</uuid>
+  <bridge name='sn2_bridge1' stp='on' delay='0'/>
+  <mac address='52:54:00:9c:37:c9'/>
+  <domain name='sn2_bridge1'/>
+</network>
+EOF
+
+virsh net-destroy sn1_bridge1
+virsh net-destroy bcn1_bridge1
+
+virsh net-undefine sn1_bridge1
+virsh net-undefine bcn1_bridge1
+
+
+# Define them
+virsh net-define /tmp/bcn1.xml
+virsh net-define /tmp/bcn2.xml
+virsh net-define /tmp/sn1.xml
+virsh net-define /tmp/sn2.xml
+
+# Set them to auto-start
+virsh net-autostart sn1_bridge1
+virsh net-autostart bcn1_bridge1
+
+# Start the networks up
+virsh net-start sn1_bridge1
+virsh net-start bcn1_bridge1
+ 


### PR DESCRIPTION
closes #89 

To make PR review easier:
- The doc changes are in [docs/Anvil Model.md](https://github.com/Seneca-CDOT/simengine/compare/issues/89-anvil-setup-doc?expand=1#diff-d8c0ad5579e159892718599b25116f62)
- Preview for the doc update can be found on [this readthedocs page](https://simengine.readthedocs.io/en/issues-89-anvil-setup-doc/Anvil%20Model/)
- ignore `data/an-*.xml` (these are virsh `.xml` configuration dumps for 4 virtual machines)
