### PR TITLE
Add UPS voltage transfer reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ nohup.out
 prebuild
 public
 
+# misc
+.todos.json

--- a/docs/Anvil Model.md
+++ b/docs/Anvil Model.md
@@ -11,7 +11,7 @@ This table summarises the general layout of the `simengine` system model we are 
 | 3       | ups01        | ups        | SNMP → reachable at 192.168.124.3 (default port 161) |
 | 4       | ups02        | ups        | SNMP → reachable at 192.168.124.4                    |
 | 5       | pdu01        | pdu        | SNMP → reachable at 192.168.124.5                    |
-| 6       | pdu02        | pdu        | SNMP → reachable at 192.168.124.3                    |
+| 6       | pdu02        | pdu        | SNMP → reachable at 192.168.124.6                    |
 | 7       | an-a01n01    | server-bmc | IPMI → reachable at localhost:9001 (or from the VM)  |
 | 8       | an-a01n02    | server-bmc | IPMI → reachable at localhost:9101 (or from the VM)  |
 | 9       | an-striker01 | server     |                                                      |

--- a/docs/Asset Management.md
+++ b/docs/Asset Management.md
@@ -99,7 +99,7 @@ You can query all thermal relationships for a particular server:
 
 Or select a specific sensor:
 
-` simengine-cli thermal sensor get --asset-key=5 --sensor='Frnt_FAN2``' `
+`simengine-cli thermal sensor get --asset-key=5 --sensor='Frnt_FAN2'`
 
 ### Configuring Interrelationships
 
@@ -121,6 +121,29 @@ will set ‘Frnt_FAN2’ to cool down ‘Mem E’ temperature every 5 seconds by
 
 !!! note
     Most thermal cases require both ‘up’ and ‘down’ events configured (‘Frnt_FAN2’ going down should result in temperature spikes for Memory slot(s)).
+
+Second thermal option - increase memory temperature when fan is not operating:
+
+    simengine-cli thermal sensor set \
+          --asset-key=5 \
+          --source-sensor='Frnt_FAN2' \
+          --target-sensor='Mem E' \
+          --event=down \
+          --action=increase \
+          --rate=5 \
+          --degrees=1 \
+          --pause-at=39
+
+This thermal behaviour can be tested by setting RPM value of a Fan#2 to 0:
+
+`simengine-cli configure-state sensor -k5 -s'Frnt_FAN2' -r0`
+
+Sensor relationships outlined above can be deleted with the following commands:
+
+```bash
+simengine-cli thermal sensor delete -s'Frnt_FAN2' -t'Mem E' -e=down -k5
+simengine-cli thermal sensor delete -s'Frnt_FAN2' -t'Mem E' -e=up -k5
+```
 
 ### Model-Based Relationship
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -17,7 +17,20 @@ To build all of the RPMs, first set the Version: in the spec files to a version
 that is tagged in the GitHub repoi (i.e., create a tag for version 20.6, and set
 Version: in the simengine\* spec files to 20.6), then run:
 
-     ${GitRepoBase}/rpm/specfiles/buildall
+     cd ${GitRepoBase)/rpm/specfiles
+     ./buildall
+
+### Building New RPMs
+
+To build a new set of RPMs, run the newtag script:
+
+     cd ${GitRepoBase}/rpm/specfiles
+     ./newtag
+     
+This will bump the product tag and adjust the Version: tags in the spec files, committing all of the changes to origin. Next, push both the code changes and the tag:
+
+     git push
+     git push --tag
 
 ## Python API
 

--- a/enginecore/.gitignore
+++ b/enginecore/.gitignore
@@ -5,4 +5,3 @@ env
 .pypirc
 *.rdb
 info.log*
-.todos.json

--- a/enginecore/.gitignore
+++ b/enginecore/.gitignore
@@ -5,3 +5,4 @@ env
 .pypirc
 *.rdb
 info.log*
+.todos.json

--- a/enginecore/enginecore/cli/model.py
+++ b/enginecore/enginecore/cli/model.py
@@ -150,10 +150,7 @@ def update_command(update_asset_group):
     update_power_parent = argparse.ArgumentParser(add_help=False)
     update_power_parent.add_argument("--power-source", type=int)
     update_power_parent.add_argument(
-        "--power-consumption",
-        type=int,
-        help="Power consumption in Watts",
-        required=True,
+        "--power-consumption", type=int, help="Power consumption in Watts"
     )
 
     update_subp = update_asset_group.add_subparsers()

--- a/enginecore/enginecore/cli/model.py
+++ b/enginecore/enginecore/cli/model.py
@@ -95,6 +95,63 @@ def model_command(asset_group):
     drop_system_action.set_defaults(func=lambda args: sys_modeler.drop_model())
 
 
+def get_ups_command_parent():
+    """Aggregate ups arg options"""
+    ups_parent = argparse.ArgumentParser(add_help=False)
+
+    ups_parent.add_argument(
+        "--full-recharge-time",
+        type=float,
+        help="""Update recharge time for UPS, time taken (hours)
+        to recharge fully depleted battery""",
+        dest="full_recharge_time",
+    )
+
+    ups_parent.add_argument(
+        "--min-power-bat",
+        type=int,
+        help="""Minimum battery level required before
+        UPS output is powered on (where 1=0.1 percent)""",
+        dest="min_power_on_battery_level",
+        choices=range(0, 1001),
+        metavar="[0-1001]",
+    )
+
+    ups_parent.add_argument(
+        "--power-capacity",
+        type=int,
+        help="Output power capacity of the UPS",
+        dest="output_power_capacity",
+        choices=range(1, 5000),
+        metavar="[1-5000]",
+    )
+
+    ups_parent.add_argument(
+        "--runtime-graph",
+        help="""Sampled runtime graph for the UPS in .JSON key-value format
+        { wattage1: minutes, wattage2: minutes }""",
+        dest="runtime",
+    )
+
+    ups_parent.add_argument(
+        "--momentary-event-time",
+        help="""Time period (in seconds) before outage/brownout
+        state is assigned in case of input power failure
+        (waits "n" seconds after momentary cause for transfer reason)""",
+        type=int,
+    )
+
+    ups_parent.add_argument(
+        "--percent-of-rated-output",
+        help="""Percentage (between 0 and 1) of nominal output voltage from the UPS
+        in VAC which determines threshold for brownout vs blackout""",
+        type=float,
+        metavar="[0.0-1.0]",
+    )
+
+    return ups_parent
+
+
 def update_command(update_asset_group):
     """Update existing asset"""
 
@@ -116,10 +173,10 @@ def update_command(update_asset_group):
     )
 
     update_asset_parent.add_argument(
-        "-x", type=int, help="x - asset position on the dashboard", default=0
+        "-x", type=int, help="x - asset position on the dashboard"
     )
     update_asset_parent.add_argument(
-        "-y", type=int, help="y - asset position on the dashboard", default=0
+        "-y", type=int, help="y - asset position on the dashboard"
     )
 
     update_asset_parent.add_argument(
@@ -138,7 +195,6 @@ def update_command(update_asset_group):
     update_snmp_parent = argparse.ArgumentParser(add_help=False)
     update_snmp_parent.add_argument("--host", type=str, help="SNMP interface host")
     update_snmp_parent.add_argument("--port", type=int, help="SNMP interface port")
-    # update_snmp_parent.add_argument('--snmp-preset', type=str, help="Vendor-specific asset configurations")
 
     # server group
     update_server_parent = argparse.ArgumentParser(add_help=False)
@@ -171,38 +227,7 @@ def update_command(update_asset_group):
     update_ups_action = update_subp.add_parser(
         "ups",
         help="Update UPS properties",
-        parents=[update_asset_parent, update_snmp_parent],
-    )
-
-    update_ups_action.add_argument(
-        "--full-recharge-time",
-        type=float,
-        help="Update recharge time for UPS, time taken (hours) to recharge fully depleted battery",
-        dest="full_recharge_time",
-    )
-
-    update_ups_action.add_argument(
-        "--min-power-bat",
-        type=int,
-        help="Minimum battery level required before UPS output is powered on (where 1=0.1 percent)",
-        dest="min_power_on_battery_level",
-        choices=range(0, 1001),
-        metavar="[0-1001]",
-    )
-
-    update_ups_action.add_argument(
-        "--power-capacity",
-        type=int,
-        help="Output power capacity of the UPS",
-        dest="output_power_capacity",
-        choices=range(1, 5000),
-        metavar="[1-5000]",
-    )
-
-    update_ups_action.add_argument(
-        "--runtime-graph",
-        help="Sampled runtime graph for the UPS in .JSON key-value format { wattage1: minutes, wattage2: minutes } ",
-        dest="runtime",
+        parents=[update_asset_parent, update_snmp_parent, get_ups_command_parent()],
     )
 
     ## Server
@@ -361,7 +386,7 @@ def create_command(create_asset_group):
     create_ups_action = create_subp.add_parser(
         "ups",
         help="Create UPS asset",
-        parents=[create_asset_parent, create_snmp_parent],
+        parents=[create_asset_parent, create_snmp_parent, get_ups_command_parent()],
     )
 
     create_ups_action.add_argument(
@@ -370,7 +395,8 @@ def create_command(create_asset_group):
     create_ups_action.add_argument(
         "--power-consumption",
         type=int,
-        help="Power consumption in Watts (how much UPS draws when not powering anything)",
+        help="""Power consumption in Watts
+          (how much UPS draws when not powering anything)""",
         default=24,
     )
 

--- a/enginecore/enginecore/cli/thermal.py
+++ b/enginecore/enginecore/cli/thermal.py
@@ -445,7 +445,7 @@ def handle_get_thermal_ambient(kwargs):
     else:
         print("Ambient: {}° ".format(ISystemEnvironment.get_ambient()))
 
-        ambient_props = ISystemEnvironment.get_ambient_props()
+        ambient_props, _ = ISystemEnvironment.get_ambient_props()
         if not ambient_props:
             print("Ambient event properties are not configured yet!")
             return

--- a/enginecore/enginecore/model/graph_reference.py
+++ b/enginecore/enginecore/model/graph_reference.py
@@ -130,7 +130,7 @@ class GraphReference:
             oid_name(str): OID name
         Returns:
             tuple: str as SNMP OID that belongs to the asset, 
-                   followed by an int as datatype, followed by optional state details; 
+                   followed by optional state details; 
                    returns None if there's no such OID
         """
 
@@ -155,19 +155,21 @@ class GraphReference:
             if (record and record["oid_details"])
             else None
         )
-        oid_data_type = details["dataType"] if oid_info else None
 
-        return oid_info, oid_data_type, v_specs
+        return oid_info, v_specs
 
     @classmethod
     def get_component_oid_by_name(cls, session, component_key, oid_name):
-        """Get OID that is associated with a particular component (by human-readable name)
+        """Get OID that is associated with a particular component
+        (by human-readable name)
+
         Args:
             session: database session
             component_key(int): key of the component
             oid_name(str): OID name
         Returns:
-            tuple: SNMP OID that belongs to the enclosing asset (as str), key of the asset component belongs to (int)
+            tuple: SNMP OID that belongs to the enclosing asset (as str);
+                   key of the asset component belongs to (int)
         """
 
         result = session.run(

--- a/enginecore/enginecore/model/graph_reference.py
+++ b/enginecore/enginecore/model/graph_reference.py
@@ -203,7 +203,8 @@ class GraphReference:
             MATCH (asset:Asset) 
             OPTIONAL MATCH (asset)-[:HAS_COMPONENT]->(component:Component)
             OPTIONAL MATCH (asset)<-[:POWERED_BY]-(childAsset:Asset) 
-            RETURN asset, count(DISTINCT component) as num_components, collect(childAsset) as children 
+            RETURN asset, count(DISTINCT component) as num_components,
+                   collect(childAsset) as children 
             ORDER BY asset.key ASC
             """
         )
@@ -225,7 +226,8 @@ class GraphReference:
 
     @classmethod
     def get_assets_and_connections(cls, session, flatten=True):
-        """Get assets, their components (e.g. PDU outlets) and parent asset(s) that powers them
+        """Get assets, their components (e.g. PDU outlets)
+        and parent asset(s) that powers them
 
         Args:
             session: database session
@@ -239,7 +241,8 @@ class GraphReference:
             MATCH (asset:Asset) WHERE NOT (asset)<-[:HAS_COMPONENT]-(:Asset)
             OPTIONAL MATCH (asset)-[:POWERED_BY]->(p:Asset)
             OPTIONAL MATCH (asset)-[:HAS_COMPONENT]->(c) 
-            RETURN asset, collect(DISTINCT c) as children,  collect(DISTINCT p) as parent
+            RETURN asset, collect(DISTINCT c) as children, 
+            collect(DISTINCT p) as parent
             """
         )
 
@@ -298,19 +301,21 @@ class GraphReference:
             asset_key(int): key of the updated asset
         
         Returns:
-            tuple: consisting of 3 (optional) items: 1) child assets that are powered by the updated asset
-                                                     2) parent(s) of the updated asset
-                                                     3) second parent of the child assets  
+            tuple: consisting of 3 (optional) items:
+                    1) child assets that are powered by the updated asset
+                    2) parent(s) of the updated asset
+                    3) second parent of the child assets
         """
 
         # look up child nodes & parent node
         results = session.run(
             """
-            OPTIONAL MATCH  (parentAsset:Asset)<-[:POWERED_BY]-(updatedAsset { key: $key }) 
+            OPTIONAL MATCH (parentAsset:Asset)<-[:POWERED_BY]-(updatedAsset { key: $key }) 
             OPTIONAL MATCH (nextAsset:Asset)-[:POWERED_BY]->({ key: $key }) 
             OPTIONAL MATCH (nextAsset2ndParent)<-[:POWERED_BY]-(nextAsset) 
             WHERE updatedAsset.key <> nextAsset2ndParent.key 
-            RETURN collect(nextAsset) as childAssets, collect(parentAsset) as parentAsset, nextAsset2ndParent
+            RETURN collect(nextAsset) as childAssets,
+                   collect(parentAsset) as parentAsset, nextAsset2ndParent
             """,
             key=asset_key,
         )
@@ -336,7 +341,8 @@ class GraphReference:
             asset_key(int): query by key
         
         Returns:
-            dict: asset details with it's 'labels' and components as 'children' (sorted by key) 
+            dict: asset details with it's 'labels' 
+                  and components as 'children' (sorted by key) 
         """
         results = session.run(
             """

--- a/enginecore/enginecore/model/presets/apc_ups.json
+++ b/enginecore/enginecore/model/presets/apc_ups.json
@@ -114,12 +114,12 @@
         },
         "AdvOutputVoltage": {
             "OID": "1.3.6.1.4.1.318.1.1.1.4.2.1.0",
-            "dataType": 2,
+            "dataType": 66,
             "defaultValue": 0
         },
         "AdvInputLineVoltage": {
             "OID": "1.3.6.1.4.1.318.1.1.1.3.2.1.0",
-            "dataType": 2,
+            "dataType": 66,
             "defaultValue": 0
         },
         "InputLineFailCause": {

--- a/enginecore/enginecore/model/presets/apc_ups.json
+++ b/enginecore/enginecore/model/presets/apc_ups.json
@@ -112,6 +112,11 @@
             "dataType": 2,
             "defaultValue": 127
         },
+        "AdvConfigRatedOutputVoltage": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.5.2.1.0",
+            "dataType": 2,
+            "defaultValue": 0
+        },
         "AdvOutputVoltage": {
             "OID": "1.3.6.1.4.1.318.1.1.1.4.2.1.0",
             "dataType": 66,

--- a/enginecore/enginecore/model/presets/apc_ups.json
+++ b/enginecore/enginecore/model/presets/apc_ups.json
@@ -1,126 +1,151 @@
 {
-  "staticOidFile": "ups/apc-ups.snmprec",
-  "assetType": "ups",
-  "SNMPSim": true,
-  "assetName": "APC UPS",
-  "numOutlets": 8,
-  "numBatteries": 1,
-  "fullRechargeTime": 2,
-  "minPowerOnBatteryLevel": 1,
-  "outputPowerCapacity": 980,
-  "modelRuntime": {
-    "50": 320,
-    "100": 185,
-    "200": 91,
-    "300": 55,
-    "400": 37,
-    "500": 26,
-    "600": 19,
-    "700": 14,
-    "800": 11,
-    "900": 9
-  },
-  "OIDs": {
-    "SerialNumber": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.1.2.3.0",
-      "dataType": 4
+    "staticOidFile": "ups/apc-ups.snmprec",
+    "assetType": "ups",
+    "SNMPSim": true,
+    "assetName": "APC UPS",
+    "numOutlets": 8,
+    "numBatteries": 1,
+    "fullRechargeTime": 2,
+    "minPowerOnBatteryLevel": 1,
+    "outputPowerCapacity": 980,
+    "modelRuntime": {
+        "50": 320,
+        "100": 185,
+        "200": 91,
+        "300": 55,
+        "400": 37,
+        "500": 26,
+        "600": 19,
+        "700": 14,
+        "800": 11,
+        "900": 9
     },
-    "MAC": {
-      "OID": "1.3.6.1.2.1.4.30.1.4.2",
-      "dataType": "4x"
-    },
-    "HighPrecBatteryCapacity": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.2.3.1.0",
-      "dataType": 66,
-      "defaultValue": 1000
-    },
-    "AdvBatteryCapacity": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.2.2.1.0",
-      "dataType": 66,
-      "defaultValue": 100
-    },
-    "BasicBatteryStatus": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.2.1.1.0",
-      "dataType": 2,
-      "defaultValue": 2,
-      "oidDesc": {
-        "2": "batteryNormal",
-        "3": "batteryLow"
-      }
-    },
-    "HighPrecBatteryTemperature": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.2.3.2.0",
-      "dataType": 66,
-      "defaultValue": 31
-    },
-    "HighPrecOutputLoad": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.4.3.3.0",
-      "dataType": 66,
-      "defaultValue": 0
-    },
-    "AdvOutputLoad": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.4.2.3.0",
-      "dataType": 66,
-      "defaultValue": 0
-    },
-    "HighPrecOutputCurrent": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.4.3.4.0",
-      "dataType": 66,
-      "defaultValue": 0
-    },
-    "AdvOutputCurrent": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.4.2.4.0",
-      "dataType": 66,
-      "defaultValue": 0
-    },
-    "BatteryRunTimeRemaining": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.2.2.3.0",
-      "dataType": 67,
-      "defaultValue": 0
-    },
-    "TimeOnBattery": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.2.1.2.0",
-      "dataType": 67,
-      "defaultValue": 0
-    },
-    "PowerOff": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.6.2.1.0",
-      "dataType": 2,
-      "defaultValue": 1,
-      "oidDesc": {
-        "2": "switchOff",
-        "3": "switchOffGraceful"
-      }
-    },
-    "BasicOutputStatus": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.4.1.1.0",
-      "dataType": 2,
-      "defaultValue": 2,
-      "oidDesc": {
-        "2": "onLine",
-        "3": "onBattery",
-        "7": "off"
-      }
-    },
-    "InputLineFailCause": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.3.2.5.0",
-      "dataType": 2,
-      "defaultValue": 1,
-      "oidDesc": {
-        "1": "noTransfer",
-        "4": "blackout",
-        "6": "deepMomentarySag"
-      }
-    },
-    "AdvConfigReturnDelay": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.5.2.9.0",
-      "dataType": 67,
-      "defaultValue": 0
-    },
-    "AdvConfigShutoffDelay": {
-      "OID": "1.3.6.1.4.1.318.1.1.1.5.2.10.0",
-      "dataType": 67,
-      "defaultValue": 0
+    "OIDs": {
+        "SerialNumber": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.1.2.3.0",
+            "dataType": 4
+        },
+        "MAC": {
+            "OID": "1.3.6.1.2.1.4.30.1.4.2",
+            "dataType": "4x"
+        },
+        "HighPrecBatteryCapacity": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.2.3.1.0",
+            "dataType": 66,
+            "defaultValue": 1000
+        },
+        "AdvBatteryCapacity": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.2.2.1.0",
+            "dataType": 66,
+            "defaultValue": 100
+        },
+        "BasicBatteryStatus": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.2.1.1.0",
+            "dataType": 2,
+            "defaultValue": 2,
+            "oidDesc": {
+                "2": "batteryNormal",
+                "3": "batteryLow"
+            }
+        },
+        "HighPrecBatteryTemperature": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.2.3.2.0",
+            "dataType": 66,
+            "defaultValue": 31
+        },
+        "HighPrecOutputLoad": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.3.3.0",
+            "dataType": 66,
+            "defaultValue": 0
+        },
+        "AdvOutputLoad": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.2.3.0",
+            "dataType": 66,
+            "defaultValue": 0
+        },
+        "HighPrecOutputCurrent": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.3.4.0",
+            "dataType": 66,
+            "defaultValue": 0
+        },
+        "AdvOutputCurrent": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.2.4.0",
+            "dataType": 66,
+            "defaultValue": 0
+        },
+        "BatteryRunTimeRemaining": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.2.2.3.0",
+            "dataType": 67,
+            "defaultValue": 0
+        },
+        "TimeOnBattery": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.2.1.2.0",
+            "dataType": 67,
+            "defaultValue": 0
+        },
+        "PowerOff": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.6.2.1.0",
+            "dataType": 2,
+            "defaultValue": 1,
+            "oidDesc": {
+                "2": "switchOff",
+                "3": "switchOffGraceful"
+            }
+        },
+        "BasicOutputStatus": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.1.1.0",
+            "dataType": 2,
+            "defaultValue": 2,
+            "oidDesc": {
+                "2": "onLine",
+                "3": "onBattery",
+                "7": "off"
+            }
+        },
+        "AdvConfigLowTransferVolt": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.5.2.3.0",
+            "dataType": 2,
+            "defaultValue": 106
+        },
+        "AdvConfigHighTransferVolt": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.5.2.2.0",
+            "dataType": 2,
+            "defaultValue": 127
+        },
+        "AdvOutputVoltage": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.2.1.0",
+            "dataType": 2,
+            "defaultValue": 0
+        },
+        "AdvInputLineVoltage": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.3.2.1.0",
+            "dataType": 2,
+            "defaultValue": 0
+        },
+        "InputLineFailCause": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.3.2.5.0",
+            "dataType": 2,
+            "defaultValue": 1,
+            "oidDesc": {
+                "1": "noTransfer",
+                "2": "highLineVoltage",
+                "3": "brownout",
+                "4": "blackout",
+                "5": "smallMomentarySag",
+                "6": "deepMomentarySag",
+                "7": "smallMomentarySpike",
+                "8": "largeMomentarySpike"
+            }
+        },
+        "AdvConfigReturnDelay": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.5.2.9.0",
+            "dataType": 67,
+            "defaultValue": 0
+        },
+        "AdvConfigShutoffDelay": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.5.2.10.0",
+            "dataType": 67,
+            "defaultValue": 0
+        }
     }
-  }
 }

--- a/enginecore/enginecore/state/agent/agent.py
+++ b/enginecore/enginecore/state/agent/agent.py
@@ -10,6 +10,7 @@ class Agent:
 
     def __init__(self):
         self._process = None
+        Agent.agent_num += 1
 
     @property
     def pid(self):

--- a/enginecore/enginecore/state/agent/ipmi_agent.py
+++ b/enginecore/enginecore/state/agent/ipmi_agent.py
@@ -15,8 +15,8 @@ from enginecore.state.agent.agent import Agent
 
 
 class IPMIAgent(Agent):
-    """Python wrapper managing ipmi_sim program that takes SensorRepository & translates it into ipmi_sim 
-    sensor definitions.
+    """Python wrapper managing ipmi_sim program that takes 
+    SensorRepository & translates it into ipmi_sim sensor definitions.
     """
 
     supported_sensors = dict.fromkeys(SUPPORTED_SENSORS, "")
@@ -30,11 +30,12 @@ class IPMIAgent(Agent):
     ]
 
     def __init__(self, ipmi_dir, ipmi_config, sensor_repo, bmc_address="0x20"):
-        """Initialize ipmi_sim working environment, define sensors based on sensor repository
-        and start ipmi_sim program.
+        """Initialize ipmi_sim working environment, define sensors
+        based on sensor repository and start ipmi_sim program.
         Args:
             ipmi_dir(str): path to simulator's work environment
-            ipmi_config(dict): connection & network device configuration (see IPMIAgent.lan_conf_attributes)
+            ipmi_config(dict): connection & network device configuration
+                               (see IPMIAgent.lan_conf_attributes)
             sensor_repo(SensorRepository): BMC sensors belonging to a particular server
             bmc_address(str): baseboard address to be used
         """
@@ -53,8 +54,6 @@ class IPMIAgent(Agent):
 
         # start process
         self.start_agent()
-
-        IPMIAgent.agent_num += 1
 
     def _substitute_template_file(self, filename, options):
         """Update file using templating
@@ -211,8 +210,15 @@ class IPMIAgent(Agent):
 
     def __str__(self):
 
+        agent_info = (
+            "\nipmi_sim lan: \n"
+            "   Accessible at: {host}:{port} \n"
+            "   User/Password:  {user}/{password}\n"
+            "   Connected to guest VM at port: {vmport} \n"
+        ).format(**self._ipmi_config)
+
         file_struct_info = (
-            "\n"
+            "\nipmi_sim files: \n"
             "   Sensor definitions file: {0.sensor_def_path}\n"
             "   Compiled sensors located in: {0.emu_state_dir_path}\n"
             "   Lan configurations: {0.lan_conf_path}\n"
@@ -220,5 +226,9 @@ class IPMIAgent(Agent):
         ).format(self)
 
         return ("\n" + "-" * 20 + "\n").join(
-            ("IPMI simulator:", super(IPMIAgent, self).__str__(), file_struct_info)
+            (
+                "IPMI simulator:",
+                super(IPMIAgent, self).__str__(),
+                file_struct_info + agent_info,
+            )
         )

--- a/enginecore/enginecore/state/agent/snmp_agent.py
+++ b/enginecore/enginecore/state/agent/snmp_agent.py
@@ -65,15 +65,6 @@ class SNMPAgent(Agent):
             pub.write(snmpsim_config)
             priv.write(snmpsim_config)
 
-        uid = pwd.getpwnam("nobody").pw_uid
-        gid = grp.getgrnam("nobody").gr_gid
-
-        os.chmod(rec_public_path, 0o777)
-        os.chmod(rec_private_path, 0o777)
-
-        os.chown(rec_public_path, uid, gid)
-        os.chown(rec_private_path, uid, gid)
-
     def start_agent(self):
         """Logic for starting up the agent """
 

--- a/enginecore/enginecore/state/agent/snmp_agent.py
+++ b/enginecore/enginecore/state/agent/snmp_agent.py
@@ -65,6 +65,15 @@ class SNMPAgent(Agent):
             pub.write(snmpsim_config)
             priv.write(snmpsim_config)
 
+        uid = pwd.getpwnam("nobody").pw_uid
+        gid = grp.getgrnam("nobody").gr_gid
+
+        os.chmod(rec_public_path, 0o777)
+        os.chmod(rec_private_path, 0o777)
+
+        os.chown(rec_public_path, uid, gid)
+        os.chown(rec_private_path, uid, gid)
+
     def start_agent(self):
         """Logic for starting up the agent """
 

--- a/enginecore/enginecore/state/agent/snmp_agent.py
+++ b/enginecore/enginecore/state/agent/snmp_agent.py
@@ -11,80 +11,101 @@ from enginecore.state.agent.agent import Agent
 
 
 class SNMPAgent(Agent):
-    """SNMP simulator """
+    """SNMP simulator/wrapper for snmpsimd.py process;
+    initializes data/work environment for snmpsimd.py with redis variation module
+    and manages simulator instance.
+    """
 
-    def __init__(
-        self,
-        key,
-        host,
-        port,
-        public_community="public",
-        private_community="private",
-        lookup_oid="1.3.6",
-    ):
-
+    def __init__(self, asset_key, snmp_conf):
         super(SNMPAgent, self).__init__()
-        self._key_space_id = key
 
-        # set up community strings
-        self._snmp_rec_public_fname = public_community + ".snmprec"
-        self._snmp_rec_private_fname = private_community + ".snmprec"
+        self._asset_key = asset_key
+        self._snmp_conf = snmp_conf
 
+        self._init_agent_environment()
+        self._init_snmprec_files()
+
+        self.start_agent()
+
+    def _init_agent_environment(self):
+        """Initialize temp work environment of the agent
+        Update ownership since snmpsimd.py will be run by user 'nobody'"""
         sys_temp = tempfile.gettempdir()
         simengine_temp = os.path.join(sys_temp, "simengine")
 
-        self._snmp_rec_dir = os.path.join(simengine_temp, str(key))
+        self._snmp_rec_dir = os.path.join(simengine_temp, str(self._asset_key))
         os.makedirs(self._snmp_rec_dir)
-        self._host = "{}:{}".format(host, port)
 
-        # snmpsimd.py will be run by a user 'nobody'
         uid = pwd.getpwnam("nobody").pw_uid
         gid = grp.getgrnam("nobody").gr_gid
 
-        # change ownership
         os.chown(self._snmp_rec_dir, uid, gid)
-        snmp_rec_public_filepath = os.path.join(
-            self._snmp_rec_dir, self._snmp_rec_public_fname
-        )
-        snmp_rec_private_filepath = os.path.join(
-            self._snmp_rec_dir, self._snmp_rec_private_fname
+
+    def _init_snmprec_files(self):
+        """Initialize data files for public/private SNMP communities
+        (files pointing to redis key-spaces for snmp devices)
+        """
+
+        # initialize community strings & lookup depth
+        rec_public_path = os.path.join(self._snmp_rec_dir, "public.snmprec")
+        rec_private_path = os.path.join(self._snmp_rec_dir, "private.snmprec")
+        lookup_oid = (
+            self._snmp_conf["lookup_oid"]
+            if "lookup_oid" in self._snmp_conf
+            else "1.3.6"
         )
 
         # get location of the lua script that will be executed by snmpsimd
         redis_script_sha = os.environ.get("SIMENGINE_SNMP_SHA")
         snmpsim_config = "{}|:redis|key-spaces-id={},evalsha={}\n".format(
-            lookup_oid, key, redis_script_sha
+            lookup_oid, self._asset_key, redis_script_sha
         )
 
-        with open(snmp_rec_public_filepath, "a") as tmp_pub, open(
-            snmp_rec_private_filepath, "a"
-        ) as tmp_priv:
-            tmp_pub.write(snmpsim_config)
-            tmp_priv.write(snmpsim_config)
-
-        self.start_agent()
-
-        SNMPAgent.agent_num += 1
+        with open(rec_public_path, "a") as pub, open(rec_private_path, "a") as priv:
+            pub.write(snmpsim_config)
+            priv.write(snmpsim_config)
 
     def start_agent(self):
         """Logic for starting up the agent """
 
-        log_file = os.path.join(self._snmp_rec_dir, "snmpsimd.log")
+        # TODO: get redis port/host from config
+        var_opt = "redis:host:127.0.0.1,port:6379,db:0,key-spaces-id:" + str(
+            self._asset_key
+        )
 
         cmd = [
             "snmpsimd.py",
-            "--agent-udpv4-endpoint={}".format(self._host),
-            "--variation-module-options=redis:host:127.0.0.1,port:6379,db:0,key-spaces-id:"
-            + str(self._key_space_id),
+            "--agent-udpv4-endpoint={host}:{port}".format(**self._snmp_conf),
+            "--variation-module-options=" + var_opt,
             "--data-dir=" + self._snmp_rec_dir,
             "--transport-id-offset=" + str(SNMPAgent.agent_num),
             "--process-user=nobody",
             "--process-group=nobody",
             # "--daemonize",
-            "--logging-method=file:" + log_file,
+            "--logging-method=file:" + self.log_path,
         ]
 
         logging.info("Starting agent: %s", " ".join(cmd))
         self.register_process(
             subprocess.Popen(cmd, stderr=subprocess.DEVNULL, close_fds=True)
+        )
+
+    @property
+    def log_path(self):
+        """Path to snmpsim log file"""
+        return os.path.join(self._snmp_rec_dir, "snmpsimd.log")
+
+    def __str__(self):
+
+        file_struct_info = (
+            "\n" "   Data directory: {0._snmp_rec_dir}\n" "   Log file: {0.log_path} \n"
+        ).format(self)
+        agent_info = ("   Accessible at: {host}:{port} \n").format(**self._snmp_conf)
+
+        return ("\n" + "-" * 20 + "\n").join(
+            (
+                "SNMP simulator:",
+                super(SNMPAgent, self).__str__(),
+                file_struct_info + agent_info,
+            )
         )

--- a/enginecore/enginecore/state/api/outlet.py
+++ b/enginecore/enginecore/state/api/outlet.py
@@ -1,8 +1,9 @@
-from enginecore.state.api.state import IStateManager
+"""Access to outlet state"""
+from enginecore.state.api.snmp_state import ISnmpDeviceStateManager
 
 from enginecore.tools.randomizer import Randomizer
 
 
 @Randomizer.register
-class IOutletStateManager(IStateManager):
+class IOutletStateManager(ISnmpDeviceStateManager):
     """Exposes state logic for Outlet asset """

--- a/enginecore/enginecore/state/api/pdu.py
+++ b/enginecore/enginecore/state/api/pdu.py
@@ -1,7 +1,9 @@
-from enginecore.state.api.state import IStateManager
+"""Access to PDU state details"""
+
 from enginecore.tools.randomizer import Randomizer
+from enginecore.state.api.snmp_state import ISnmpDeviceStateManager
 
 
 @Randomizer.register
-class IPDUStateManager(IStateManager):
+class IPDUStateManager(ISnmpDeviceStateManager):
     """Handles state logic for PDU asset """

--- a/enginecore/enginecore/state/api/snmp_state.py
+++ b/enginecore/enginecore/state/api/snmp_state.py
@@ -1,0 +1,73 @@
+"""SNMP device provides access snmp state"""
+from collections import namedtuple
+
+from enginecore.state.api.state import IStateManager
+from enginecore.model.graph_reference import GraphReference
+from enginecore.tools.utils import format_as_redis_key
+
+
+class ISnmpDeviceStateManager(IStateManager):
+    """Stores snmp-related interface features such as access to OIDs"""
+
+    ObjectIdentity = namedtuple("ObjectIdentity", "oid specs")
+
+    def _update_oid_by_name(self, oid_name, value, use_spec=False):
+        """Update a specific oid
+        Args:
+            oid_name(str): oid name defined in device preset file
+            value(str): oid value or spec parameter if use_spec is set to True
+            use_spec: for enumeration oid types
+        Returns:
+            bool: true if oid was successfully updated
+        """
+
+        with self._graph_ref.get_session() as db_s:
+            oid = ISnmpDeviceStateManager.ObjectIdentity(
+                *GraphReference.get_asset_oid_by_name(
+                    db_s, int(self._asset_key), oid_name
+                )
+            )
+
+        if oid:
+            new_oid_value = oid.specs[value] if use_spec and oid.specs else value
+            self._update_oid_value(oid, new_oid_value)
+            return True
+
+        return False
+
+    def _update_oid_value(self, object_id, oid_value):
+        """Update oid with a new value
+        
+        Args:
+            object_id(ISnmpDeviceStateManager.ObjectIdentity): SNMP object id
+            oid_value(object): OID value in rfc1902 format 
+        """
+        redis_store = IStateManager.get_store()
+        rkey = format_as_redis_key(
+            str(self._asset_key), object_id.oid, key_formatted=False
+        )
+
+        data_type = int(redis_store.get(rkey).decode().split("|")[0])
+        rvalue = "{}|{}".format(data_type, oid_value)
+
+        redis_store.set(rkey, rvalue)
+
+    def _get_oid_value(self, object_id, key=None):
+        """Retrieve value for a specific OID """
+        if key is None:
+            key = self.key
+
+        redis_store = IStateManager.get_store()
+        rkey = format_as_redis_key(str(key), object_id.oid, key_formatted=False)
+        return redis_store.get(rkey).decode().split("|")[1]
+
+    def _get_oid_by_name(self, oid_name):
+        """Get oid by oid name"""
+
+        with self._graph_ref.get_session() as db_s:
+            oid = ISnmpDeviceStateManager.ObjectIdentity(
+                *GraphReference.get_asset_oid_by_name(
+                    db_s, int(self._asset_key), oid_name
+                )
+            )
+        return oid

--- a/enginecore/enginecore/state/api/snmp_state.py
+++ b/enginecore/enginecore/state/api/snmp_state.py
@@ -11,6 +11,11 @@ class ISnmpDeviceStateManager(IStateManager):
 
     ObjectIdentity = namedtuple("ObjectIdentity", "oid specs")
 
+    @property
+    def snmp_config(self):
+        """Snmp lan configurations"""
+        return {"host": self._asset_info["host"], "port": self._asset_info["port"]}
+
     def _update_oid_by_name(self, oid_name, value, use_spec=False):
         """Update a specific oid
         Args:

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -186,8 +186,11 @@ class IStateManager:
             json.dumps({"key": self.key, "status": self.status}),
         )
 
-    def _get_oid_value(self, oid, key):
+    def _get_oid_value(self, oid, key=None):
         """Retrieve value for a specific OID """
+        if key is None:
+            key = self.key
+
         redis_store = IStateManager.get_store()
         rkey = format_as_redis_key(str(key), oid, key_formatted=False)
         return redis_store.get(rkey).decode().split("|")[1]

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -255,9 +255,10 @@ class IStateManager:
         if not keys:
             return True
 
-        parent_values = IStateManager.get_store().mget([k + ":state" for k in keys])
+        parent_values = IStateManager.get_store().mget(keys)
         pdown = 0
         pdown_msg = ""
+
         for rkey, rvalue in zip(keys, parent_values):
             if parent_down(rvalue, rkey):
                 pdown_msg += msg.format(rkey) + "\n"
@@ -285,7 +286,9 @@ class IStateManager:
         if not asset_keys and not ISystemEnvironment.power_source_available():
             not_affected_by_mains = False
 
-        assets_up = self._check_parents(asset_keys, lambda rvalue, _: rvalue == b"0")
+        assets_up = self._check_parents(
+            [k + ":state" for k in asset_keys], lambda rvalue, _: rvalue == b"0"
+        )
         oid_clause = (
             lambda rvalue, rkey: rvalue.split(b"|")[1].decode()
             == oid_keys[rkey]["switchOff"]

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -195,6 +195,16 @@ class IStateManager:
         rkey = format_as_redis_key(str(key), oid, key_formatted=False)
         return redis_store.get(rkey).decode().split("|")[1]
 
+    def _get_oid_by_name(self, oid_name):
+        """Get oid by oid name"""
+
+        with self._graph_ref.get_session() as db_s:
+            oid_details = GraphReference.get_asset_oid_by_name(
+                db_s, int(self._asset_key), oid_name
+            )
+
+        return oid_details
+
     def _reset_boot_time(self):
         """Reset device start time (this redis key/value is used to calculate uptime)
         (see snmppub.lua)

--- a/enginecore/enginecore/state/api/state.py
+++ b/enginecore/enginecore/state/api/state.py
@@ -72,7 +72,7 @@ class IStateManager:
         """Get minimum voltage required and the poweroff timeout associated with it"""
 
         if not "minVoltage" in self._asset_info:
-            return None, None
+            return 90, None
 
         return self._asset_info["minVoltage"], self._asset_info["voltPowerTimeout"]
 

--- a/enginecore/enginecore/state/api/ups.py
+++ b/enginecore/enginecore/state/api/ups.py
@@ -93,6 +93,11 @@ class IUPSStateManager(ISnmpDeviceStateManager):
         return self._max_battery_level
 
     @property
+    def on_battery(self):
+        """Indicates if UPS is powered by battery at the moment"""
+        return self.get_transfer_reason() != self.InputLineFailCause.noTransfer
+
+    @property
     def wattage(self):
         return (self.load + self.idle_ups_amp) * self._asset_info["powerSource"]
 
@@ -166,6 +171,14 @@ class IUPSStateManager(ISnmpDeviceStateManager):
             self._reset_power_off_oid()
 
         return powered
+
+    def get_transfer_reason(self):
+        """Retrieve last transfer reason (why switched from input power to battery)
+        Returns:
+            InputLineFailCause: last transfer cause
+        """
+        oid_t_reason = self._get_oid_by_name("InputLineFailCause")
+        return self.InputLineFailCause(int(self._get_oid_value(oid_t_reason)))
 
     def get_config_off_delay(self):
         """Delay for power-off operation 

--- a/enginecore/enginecore/state/api/ups.py
+++ b/enginecore/enginecore/state/api/ups.py
@@ -24,11 +24,51 @@ class IUPSStateManager(IStateManager):
         off = 3
 
     class InputLineFailCause(Enum):
-        """Reason for the occurrence of the last transfer to UPS """
+        """Reason for the occurrence of the last transfer to UPS
+        The variable is set to:
+            - noTransfer(1) -- if there is no transfer yet.
+
+            - highLineVoltage(2) -- if the transfer to battery is caused
+            by an over voltage greater than the high transfer voltage.
+            
+            - brownout(3) -- if the duration of the outage is greater than
+            five seconds and the line voltage is between 40% of the
+            rated output voltage and the low transfer voltage.
+            
+            - blackout(4) -- if the duration of the outage is greater than five
+            seconds and the line voltage is between 40% of the rated
+            output voltage and ground.
+            
+            - smallMomentarySag(5) -- if the duration of the outage is less
+            than five seconds and the line voltage is between 40% of the
+            rated output voltage and the low transfer voltage.
+            
+            - deepMomentarySag(6) -- if the duration of the outage is less
+            than five seconds and the line voltage is between 40% of the
+            rated output voltage and ground.  The variable is set to
+            
+            - smallMomentarySpike(7) -- if the line failure is caused by a
+            rate of change of input voltage less than ten volts per cycle.
+            
+            - largeMomentarySpike(8) -- if the line failure is caused by
+            a rate of change of input voltage greater than ten volts per cycle.
+            
+            - selfTest(9) -- if the UPS was commanded to do a self test.
+            
+            - rateOfVoltageChange(10) -- if the failure is due to the rate of change of
+            the line voltage.
+        """
 
         noTransfer = 1
-        blackout = 2
-        deepMomentarySag = 3
+        highLineVoltage = 2
+        brownout = 3
+        blackout = 4
+        smallMomentarySag = 5
+        deepMomentarySag = 6
+        smallMomentarySpike = 7
+        largeMomentarySpike = 8
+        selfTest = 9
+        rateOfVoltageChange = 10
 
     def __init__(self, asset_info):
         super().__init__(asset_info)

--- a/enginecore/enginecore/state/api/ups.py
+++ b/enginecore/enginecore/state/api/ups.py
@@ -118,13 +118,32 @@ class IUPSStateManager(ISnmpDeviceStateManager):
 
     @property
     def rated_output_threshold(self):
+        """Threshold derived from the rated output used to determine
+        if transfer to battery is needed (see IUPSStateManager.InputLineFailCause)
+        """
+        ro_percent = 0.4
+
         if "ratedOutputPercentage" in self._asset_info:
             ro_percent = self._asset_info["ratedOutputPercentage"]
-        else:
-            ro_percent = 0.4
 
-        in_voltage_oid = self._get_oid_by_name("AdvInputLineVoltage")
+        in_voltage_oid = self._get_oid_by_name("AdvConfigRatedOutputVoltage")
         return ro_percent * int(self._get_oid_value(in_voltage_oid))
+
+    @property
+    def momentary_event_period(self):
+        """Power sag/spike time period. Momentary event
+        (see IUPSStateManager.InputLineFailCause) happens
+        before transfer reason is assigned an elevated severity.
+
+        Returns:
+            int: time period in seconds
+        """
+        t_period = 5  # seconds
+
+        if "momentaryEventTime" in self._asset_info:
+            t_period = self._asset_info["momentaryEventTime"]
+
+        return t_period
 
     @Randomizer.randomize_method()
     def shut_down(self):

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -245,7 +245,7 @@ class Engine(Component):
     def _chain_voltage_update(self, event_result: VoltageEventResult):
         """Chain voltage updates down the power stream"""
 
-        logging.info("VOLTAGE CHAIN")
+        # logging.info("VOLTAGE CHAIN")
 
         with self._graph_ref.get_session() as session:
             close_nodes = GraphReference.get_affected_assets(

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -235,9 +235,7 @@ class Engine(Component):
             PowerEventResult(asset_key=asset_key, new_state=asset_status)
         )
 
-    def _chain_voltage_update(
-        self, event_result: VoltageEventResult, increased: bool = True
-    ):
+    def _chain_voltage_update(self, event_result: VoltageEventResult):
         """Chain voltage updates down the power stream"""
 
         logging.info("VOLTAGE CHAIN")
@@ -302,7 +300,7 @@ class Engine(Component):
         Args:
             updated_asset: leaf node asset with new power state
             new_state: new power state
-            parent_assets: assets powering the leaf node
+            parent_assets: assets powering the leaf node (list of dictionaries not Assets)
         """
         offline_parents_load = 0
         online_parents = []
@@ -624,4 +622,6 @@ class Engine(Component):
             self._chain_voltage_update(e_result)
 
     def VoltageIncreased_success(self, evt, e_result):
-        pass
+        """When asset finished processing new voltage"""
+        if e_result.old_voltage != e_result.new_voltage:
+            self._chain_voltage_update(e_result)

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -17,6 +17,7 @@ from circuits.web.dispatchers import WebSocketsDispatcher
 from enginecore.state.hardware.event_results import PowerEventResult, LoadEventResult
 from enginecore.state.hardware.room import ServerRoom, Asset
 
+from enginecore.tools.recorder import RECORDER
 from enginecore.state.api import ISystemEnvironment
 from enginecore.state.event_map import PowerEventMap
 from enginecore.state.net.ws_server import WebSocket
@@ -76,7 +77,7 @@ class Engine(Component):
         self._ws = WebSocket().register(self._server)
         WebSocketsDispatcher("/simengine").register(self._server)
 
-        ### Register Assets ###
+        # Register assets and reset power state
         self._reload_model(force_snmp_init)
 
         logging.info("Physical Environment:\n%s", self._sys_environ)
@@ -84,6 +85,7 @@ class Engine(Component):
     def _reload_model(self, force_snmp_init=True):
         """Re-create system topology (instantiate assets based on graph ref)"""
 
+        RECORDER.enabled = False
         logging.info("Initializing system topology...")
 
         self._assets = {}
@@ -133,6 +135,7 @@ class Engine(Component):
             )
 
         ISystemEnvironment.set_ambient(21)
+        RECORDER.enabled = True
 
     def _handle_wallpower_update(self, power_up=True):
         """Change status of wall-powered assets (outlets)

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -167,6 +167,7 @@ class Engine(Component):
             value(str): OID value in snmpsim format "datatype|value"
         """
         if asset_key not in self._assets:
+            logging.warning("Asset [%s] does not exist!", asset_key)
             return
 
         oid = oid.replace(" ", "")
@@ -176,14 +177,20 @@ class Engine(Component):
                 session, asset_key, oid
             )
 
-            oid_value_name = oid_details["specs"][oid_value]
-            oid_name = oid_details["name"]
+        if not oid_details:
+            logging.warning(
+                "OID:[%s] for asset:[%s] cannot be processed by engine!", oid, asset_key
+            )
+            return
 
-            for key in affected_keys:
-                self.fire(
-                    PowerEventMap.get_state_specs()[oid_name][oid_value_name],
-                    self._assets[key],
-                )
+        oid_value_name = oid_details["specs"][oid_value]
+        oid_name = oid_details["name"]
+
+        for key in affected_keys:
+            self.fire(
+                PowerEventMap.get_state_specs()[oid_name][oid_value_name],
+                self._assets[key],
+            )
 
         logging.info("oid changed:")
         logging.info(">" + oid + ": " + oid_value)

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -335,7 +335,8 @@ class Engine(Component):
                 (server) <- child
         """
 
-        child_load = child_asset.state.load * updated_asset.state.draw_percentage
+        child_load = child_asset.state.power_usage * updated_asset.state.draw_percentage
+
         get_child_load_event = lambda new_state: (
             PowerEventMap.map_load_decreased_by,
             PowerEventMap.map_load_increased_by,

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -630,5 +630,4 @@ class Engine(Component):
 
     def VoltageIncreased_success(self, evt, e_result):
         """When asset finished processing new voltage"""
-        if e_result.old_voltage != e_result.new_voltage:
-            self._chain_voltage_update(e_result)
+        self._chain_voltage_update(e_result)

--- a/enginecore/enginecore/state/engine.py
+++ b/enginecore/enginecore/state/engine.py
@@ -14,7 +14,11 @@ import redis
 from circuits.web import Logger, Server, Static
 from circuits.web.dispatchers import WebSocketsDispatcher
 
-from enginecore.state.hardware.event_results import PowerEventResult, LoadEventResult
+from enginecore.state.hardware.event_results import (
+    PowerEventResult,
+    LoadEventResult,
+    VoltageEventResult,
+)
 from enginecore.state.hardware.room import ServerRoom, Asset
 
 from enginecore.tools.recorder import RECORDER
@@ -147,7 +151,7 @@ class Engine(Component):
 
         mains_out = {k: self._assets[k] for k in mains_out_keys if k}
 
-        for _, outlet in mains_out.items():
+        for outlet in mains_out.values():
             if not power_up and outlet.state.status != 0:
                 outlet.state.shut_down()
                 outlet.state.publish_power()
@@ -200,6 +204,17 @@ class Engine(Component):
                 PowerEventMap.map_ambient_event(old_temp, new_temp), self._assets[a_key]
             )
 
+    def _handle_voltage_update(self, old_voltage, new_voltage):
+        """let devices handle voltage updates"""
+
+        with self._graph_ref.get_session() as session:
+            mains_out_keys = GraphReference.get_mains_powered_outlets(session)
+
+        mains_out = {k: self._assets[k] for k in mains_out_keys if k}
+
+        for outlet in mains_out.values():
+            self.fire(PowerEventMap.map_voltage_event(old_voltage, new_voltage), outlet)
+
     def _handle_state_update(self, asset_key, asset_status):
         """React to asset state updates in redis store 
         Args:
@@ -219,6 +234,26 @@ class Engine(Component):
         self._chain_power_update(
             PowerEventResult(asset_key=asset_key, new_state=asset_status)
         )
+
+    def _chain_voltage_update(
+        self, event_result: VoltageEventResult, increased: bool = True
+    ):
+        """Chain voltage updates down the power stream"""
+
+        logging.info("VOLTAGE CHAIN")
+
+        with self._graph_ref.get_session() as session:
+            close_nodes = GraphReference.get_affected_assets(
+                session, event_result.asset_key
+            )
+
+        voltage_param = (event_result.old_voltage, event_result.new_voltage)
+
+        for child in close_nodes[0]:
+            self.fire(
+                PowerEventMap.map_voltage_event(*voltage_param),
+                self._assets[child["key"]],
+            )
 
     def _chain_load_update(self, event_result: LoadEventResult, increased: bool = True):
         """React to load update event by propogating the load changes 
@@ -388,8 +423,8 @@ class Engine(Component):
             the assets it powers should be powered down as well
         """
 
-        updated_asset = self._assets[int(event_result.asset_key)]
-        new_state = int(event_result.new_state)
+        updated_asset = self._assets[event_result.asset_key]
+        new_state = event_result.new_state
 
         with self._graph_ref.get_session() as session:
             children, parent_assets, _2nd_parent = GraphReference.get_affected_assets(
@@ -438,8 +473,8 @@ class Engine(Component):
         elif old_voltage < ISystemEnvironment.get_min_voltage() <= new_voltage:
             self._handle_wallpower_update(power_up=True)
 
-        event = PowerEventMap.map_voltage_event(old_voltage, new_voltage)
-        # list(map(lambda asset: self.fire(event, asset), self._assets.values()))
+        # event = PowerEventMap.map_voltage_event(old_voltage, new_voltage)
+        self._handle_voltage_update(old_voltage, new_voltage)
 
     @handler(RedisChannels.mains_update_channel)
     def on_wallpower_state_change(self, data):
@@ -581,3 +616,12 @@ class Engine(Component):
             ServerToClientRequests.asset_upd,
             {"key": e_result.asset_key, "status": e_result.new_state},
         )
+
+    def VoltageDecreased_success(self, evt, e_result):
+        """When asset finished processing new voltage
+        and it stayed online"""
+        if e_result.old_voltage != e_result.new_voltage:
+            self._chain_voltage_update(e_result)
+
+    def VoltageIncreased_success(self, evt, e_result):
+        pass

--- a/enginecore/enginecore/state/hardware/asset.py
+++ b/enginecore/enginecore/state/hardware/asset.py
@@ -131,12 +131,12 @@ class Asset(Component):
             new_voltage=kwargs["new_value"],
         )
 
-        min_voltage, _ = self.state.min_voltage_prop()
+        # min_voltage, _ = self.state.min_voltage_prop()
 
-        if kwargs["new_value"] >= min_voltage and not self.state.status:
-            self.state.power_up()
-            self.state.publish_power()
-            event.success = False
+        # if kwargs["new_value"] >= min_voltage and not self.state.status:
+        #     self.state.power_up()
+        #     self.state.publish_power()
+        #     event.success = False
 
         return e_result
 
@@ -151,15 +151,15 @@ class Asset(Component):
             new_voltage=kwargs["new_value"],
         )
 
-        min_voltage, power_off_timeout = self.state.min_voltage_prop()
-        if kwargs["new_value"] < min_voltage and self.state.status:
+        # min_voltage, power_off_timeout = self.state.min_voltage_prop()
+        # if kwargs["new_value"] < min_voltage and self.state.status:
 
-            if power_off_timeout:
-                time.sleep(power_off_timeout)
+        #     if power_off_timeout:
+        #         time.sleep(power_off_timeout)
 
-            self.state.power_off()
-            self.state.publish_power()
-            event.success = False
+        #     self.state.power_off()
+        #     self.state.publish_power()
+        #     event.success = False
 
         return e_result
 

--- a/enginecore/enginecore/state/hardware/asset.py
+++ b/enginecore/enginecore/state/hardware/asset.py
@@ -123,8 +123,7 @@ class Asset(Component):
 
     @handler("VoltageIncreased")
     def on_voltage_increase(self, event, *args, **kwargs):
-        print("\n", "VOLTAGE InCREASED", event, kwargs, args, "\n")
-
+        """Handle input power voltage increase"""
         e_result = event_results.VoltageEventResult(
             asset_key=self.state.key,
             asset_type=self.state.asset_type,
@@ -133,16 +132,18 @@ class Asset(Component):
         )
 
         min_voltage, _ = self.state.min_voltage_prop()
+
         if kwargs["new_value"] >= min_voltage and not self.state.status:
             self.state.power_up()
             self.state.publish_power()
-            # event.success = False
+            event.success = False
 
         return e_result
 
     @handler("VoltageDecreased")
     def on_voltage_decrease(self, event, *args, **kwargs):
-        print("\n", "VOLTAGE deCREASED", event, kwargs, args, "\n")
+        """Handle input power voltage drop"""
+
         e_result = event_results.VoltageEventResult(
             asset_key=self.state.key,
             asset_type=self.state.asset_type,
@@ -152,7 +153,10 @@ class Asset(Component):
 
         min_voltage, power_off_timeout = self.state.min_voltage_prop()
         if kwargs["new_value"] < min_voltage and self.state.status:
-            time.sleep(power_off_timeout)
+
+            if power_off_timeout:
+                time.sleep(power_off_timeout)
+
             self.state.power_off()
             self.state.publish_power()
             event.success = False

--- a/enginecore/enginecore/state/hardware/asset.py
+++ b/enginecore/enginecore/state/hardware/asset.py
@@ -74,11 +74,13 @@ class Asset(Component):
         
         Args:
             load_change(float): how much AMPs need to be added/subtracted
-            arithmetic_op(callable): calculates new load (receives old load & measured load change)
+            arithmetic_op(callable): calculates new load
+                                     (receives old load & measured load change)
             msg(str): message to be printed
         
         Returns:
-            LoadEventResult: Event result containing old & new load values as well as value subtracted/added
+            LoadEventResult: Event result containing old 
+                             & new load values as well as value subtracted/added
         """
 
         old_load = self.state.load
@@ -117,6 +119,27 @@ class Asset(Component):
         decreased_by = kwargs["child_load"]
         msg = "Asset:[{}] load {} was decreased by {}, new load={};"
         return self._update_load(decreased_by, lambda old, change: old - change, msg)
+
+    @handler("VoltageIncreased")
+    def on_voltage_increase(self, event, *args, **kwargs):
+        print("\n", "VOLTAGE InCREASED", event, kwargs, args, "\n")
+
+        return event_results.VoltageEventResult(
+            asset_key=self.state.key,
+            asset_type=self.state.asset_type,
+            old_voltage=120,
+            new_voltage=120,
+        )
+
+    @handler("VoltageDecreased")
+    def on_voltage_decrease(self, event, *args, **kwargs):
+        print("\n", "VOLTAGE deCREASED", event, kwargs, args, "\n")
+        return event_results.VoltageEventResult(
+            asset_key=self.state.key,
+            asset_type=self.state.asset_type,
+            old_voltage=kwargs["old_value"],
+            new_voltage=kwargs["new_value"],
+        )
 
     @classmethod
     def get_supported_assets(cls):

--- a/enginecore/enginecore/state/hardware/asset_events.py
+++ b/enginecore/enginecore/state/hardware/asset_events.py
@@ -53,13 +53,13 @@ class ChildAssetLoadDecreased(Event):
 class VoltageIncreased(Event):
     """Voltage spike/increase for the Asset"""
 
-    pass
+    success = True
 
 
 class VoltageDecreased(Event):
     """Voltage drop for the Asset"""
 
-    pass
+    success = True
 
 
 class SignalDown(Event):

--- a/enginecore/enginecore/state/hardware/event_results.py
+++ b/enginecore/enginecore/state/hardware/event_results.py
@@ -1,5 +1,6 @@
 """Aggregates Assets' responses to certain events
-For example, PowerEventResult will be returned to the dispatcher in case the dispatched event was handled succesfully
+For example, PowerEventResult will be returned to the dispatcher
+in case the dispatched event was handled succesfully
 """
 
 from collections import namedtuple
@@ -8,7 +9,13 @@ PowerEventResult = namedtuple(
     "PowerEventResult", "old_state new_state asset_key asset_type"
 )
 PowerEventResult.__new__.__defaults__ = (None,) * len(PowerEventResult._fields)
+
 LoadEventResult = namedtuple(
     "LoadEventResult", "load_change old_load new_load asset_key asset_type"
 )
 LoadEventResult.__new__.__defaults__ = (None,) * len(PowerEventResult._fields)
+
+VoltageEventResult = namedtuple(
+    "VoltageEventResult", "old_voltage new_voltage asset_key asset_type"
+)
+VoltageEventResult.__new__.__defaults__ = (None,) * len(VoltageEventResult._fields)

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -107,14 +107,6 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         """
         self._update_oid_by_name("InputLineFailCause", status.name, use_spec=True)
 
-    def get_transfer_reason(self):
-        """Retrieve last transfer reason (why switched from input power to battery)
-        Returns:
-            InputLineFailCause: last transfer cause
-        """
-        oid_t_reason = self._get_oid_by_name("InputLineFailCause")
-        return self.InputLineFailCause(int(self._get_oid_value(oid_t_reason)))
-
     def _update_current_oids(self, load):
         """Update OIDs associated with UPS Output - Current in AMPs
         

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -111,6 +111,14 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
             "InputLineFailCause", snmp_data_types.Integer, status.name, use_spec=True
         )
 
+    def get_transfer_reason(self):
+        """Retrieve last transfer reason (why switched from input power to battery)
+        Returns:
+            InputLineFailCause: last transfer cause
+        """
+        oid_treason, _, _ = self._get_oid_by_name("InputLineFailCause")
+        return self.InputLineFailCause(int(self._get_oid_value(oid_treason)))
+
     def _update_current_oids(self, load):
         """Update OIDs associated with UPS Output - Current in AMPs
         
@@ -179,11 +187,6 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
             self._update_oid_value(
                 oid_basic, dt_basic, snmp_data_types.Integer32(norm_bat_value)
             )
-
-    # @property
-    # def input_voltage(self):
-    #     oid_in_adv, _, _ = self._get_oid_by_name("AdvInputLineVoltage")
-    #     return int(self._get_oid_value(oid_in_adv))
 
     def process_voltage(self, voltage):
         """Update oids associated with UPS voltage

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -217,11 +217,11 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
             return False, None
 
         # new voltage should cause line transfer:
-        _40percent_of_rated_out = int(self._get_oid_value(oid_out_adv)) * 0.4
+        r_out_threshold = self.rated_output_threshold
 
-        if _40percent_of_rated_out <= voltage <= low_th:
+        if r_out_threshold <= voltage <= low_th:
             transfer_reason = self.InputLineFailCause.smallMomentarySag
-        elif 0 <= voltage < _40percent_of_rated_out:
+        elif 0 <= voltage < r_out_threshold:
             transfer_reason = self.InputLineFailCause.deepMomentarySag
         elif voltage >= high_th:
             transfer_reason = self.InputLineFailCause.highLineVoltage

--- a/enginecore/enginecore/state/hardware/pdu_asset.py
+++ b/enginecore/enginecore/state/hardware/pdu_asset.py
@@ -29,7 +29,9 @@ class PDU(Asset, SNMPSim):
     def __init__(self, asset_info):
         Asset.__init__(self, PDU.StateManagerCls(asset_info))
         SNMPSim.__init__(
-            self, asset_info["key"], asset_info["host"], asset_info["port"]
+            self,
+            asset_info["key"],
+            snmp_conf={"host": asset_info["host"], "port": asset_info["port"]},
         )
 
         self.state.update_agent(self._snmp_agent.pid)

--- a/enginecore/enginecore/state/hardware/pdu_asset.py
+++ b/enginecore/enginecore/state/hardware/pdu_asset.py
@@ -27,15 +27,8 @@ class PDU(Asset, SNMPSim):
     StateManagerCls = in_state.PDUStateManager
 
     def __init__(self, asset_info):
-        Asset.__init__(self, PDU.StateManagerCls(asset_info))
-        SNMPSim.__init__(
-            self,
-            asset_info["key"],
-            snmp_conf={"host": asset_info["host"], "port": asset_info["port"]},
-        )
-
-        self.state.update_agent(self._snmp_agent.pid)
-        logging.info(self._snmp_agent)
+        Asset.__init__(self, state=PDU.StateManagerCls(asset_info))
+        SNMPSim.__init__(self, self._state)
 
     @handler("ParentAssetPowerDown")
     def on_parent_asset_power_down(self, event, *args, **kwargs):

--- a/enginecore/enginecore/state/hardware/server_asset.py
+++ b/enginecore/enginecore/state/hardware/server_asset.py
@@ -121,14 +121,14 @@ class ServerWithBMC(Server):
         """Add new thermal cpu load & sensor relationship"""
         self._sensor_repo.get_sensor_by_name(target).add_cpu_thermal_impact()
 
-    def add_storage_cv_thermal_impact(self, source, controller, cv, event):
+    def add_storage_cv_thermal_impact(self, source, controller, cache_v, event):
         """Add new sensor & cachevault thermal relationship
         Args:
             source(str): name of the source sensor causing thermal changes
-            cv(str): serial number of the cachevault
+            cache_v(str): serial number of the cachevault
         """
         sensor = self._sensor_repo.get_sensor_by_name(source)
-        sensor.add_cv_thermal_impact(controller, cv, event)
+        sensor.add_cv_thermal_impact(controller, cache_v, event)
 
     def add_storage_pd_thermal_impact(self, source, controller, drive, event):
         """Add new sensor & physical drive thermal relationship
@@ -167,10 +167,12 @@ class ServerWithBMC(Server):
 
     @handler("ButtonPowerDownPressed")
     def on_asset_did_power_off(self):
+        """Set sensors to off values on power down (no power source)"""
         self._sensor_repo.shut_down_sensors()
 
     @handler("ButtonPowerUpPressed")
     def on_asset_did_power_on(self):
+        """Update senosrs on power online"""
         self._sensor_repo.power_up_sensors()
 
 

--- a/enginecore/enginecore/state/hardware/snmp_asset.py
+++ b/enginecore/enginecore/state/hardware/snmp_asset.py
@@ -7,8 +7,8 @@ from enginecore.state.agent import SNMPAgent
 class SNMPSim:
     """Snmp simulator running snmpsim program"""
 
-    def __init__(self, key, host, port):
-        self._snmp_agent = SNMPAgent(key, host, port)
+    def __init__(self, asset_key, snmp_conf):
+        self._snmp_agent = SNMPAgent(asset_key, snmp_conf)
 
     @handler("ButtonPowerDownPressed")
     def on_asset_did_power_off(self):

--- a/enginecore/enginecore/state/hardware/snmp_asset.py
+++ b/enginecore/enginecore/state/hardware/snmp_asset.py
@@ -1,5 +1,7 @@
 """Aggregates event-handling logic for devices supporting SNMP interface"""
 
+import logging
+
 from circuits import handler
 from enginecore.state.agent import SNMPAgent
 
@@ -7,8 +9,11 @@ from enginecore.state.agent import SNMPAgent
 class SNMPSim:
     """Snmp simulator running snmpsim program"""
 
-    def __init__(self, asset_key, snmp_conf):
-        self._snmp_agent = SNMPAgent(asset_key, snmp_conf)
+    def __init__(self, state):
+        self._snmp_agent = SNMPAgent(state.key, state.snmp_config)
+        state.update_agent(self._snmp_agent.pid)
+
+        logging.info(self._snmp_agent)
 
     @handler("ButtonPowerDownPressed")
     def on_asset_did_power_off(self):

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -169,7 +169,9 @@ class UPS(Asset, SNMPSim):
 
             time.sleep(1)
 
-    def _launch_battery_drain(self):
+    def _launch_battery_drain(
+        self, t_reason=in_state.UPSStateManager.InputLineFailCause.deepMomentarySag
+    ):
         """Start a thread that will decrease battery level """
 
         self._start_time_battery = dt.now()
@@ -178,9 +180,7 @@ class UPS(Asset, SNMPSim):
         self.state.update_ups_output_status(
             in_state.UPSStateManager.OutputStatus.onBattery
         )
-        self.state.update_transfer_reason(
-            in_state.UPSStateManager.InputLineFailCause.deepMomentarySag
-        )
+        self.state.update_transfer_reason(t_reason)
 
         # launch a thread
         self._battery_drain_t = Thread(

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -32,14 +32,8 @@ class UPS(Asset, SNMPSim):
     StateManagerCls = in_state.UPSStateManager
 
     def __init__(self, asset_info):
-        Asset.__init__(self, UPS.StateManagerCls(asset_info))
-        SNMPSim.__init__(
-            self,
-            asset_info["key"],
-            snmp_conf={"host": asset_info["host"], "port": asset_info["port"]},
-        )
-
-        self.state.update_agent(self._snmp_agent.pid)
+        Asset.__init__(self, state=UPS.StateManagerCls(asset_info))
+        SNMPSim.__init__(self, self._state)
 
         # Store known { wattage: time_remaining } key/value pairs (runtime graph)
         self._runtime_details = json.loads(asset_info["runtime"])
@@ -65,7 +59,6 @@ class UPS(Asset, SNMPSim):
 
         # set temp on start
         self._state.update_temperature(7)
-        logging.info(self._snmp_agent)
 
     def _cacl_time_left(self, wattage):
         """Approximate runtime estimation based on current battery level"""

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -34,7 +34,9 @@ class UPS(Asset, SNMPSim):
     def __init__(self, asset_info):
         Asset.__init__(self, UPS.StateManagerCls(asset_info))
         SNMPSim.__init__(
-            self, asset_info["key"], asset_info["host"], asset_info["port"]
+            self,
+            asset_info["key"],
+            snmp_conf={"host": asset_info["host"], "port": asset_info["port"]},
         )
 
         self.state.update_agent(self._snmp_agent.pid)

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -92,6 +92,9 @@ class UPS(Asset, SNMPSim):
         return self.state.battery_max_level / (fp_estimated_timeleft * 60)
 
     def _increase_transfer_severity(self):
+        """Increase severity of the input power event
+        (blackout, brownout etc. )
+        """
 
         last_reason = self.state.get_transfer_reason()
 
@@ -132,7 +135,7 @@ class UPS(Asset, SNMPSim):
             )
             self.state.update_time_on_battery(seconds_on_battery * 100)
 
-            if seconds_on_battery > 5 and not outage:
+            if seconds_on_battery > self.state.momentary_event_period and not outage:
                 outage = True
                 self._increase_transfer_severity()
 

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -80,7 +80,8 @@ class UPS(Asset, SNMPSim):
         return (close_timeleft * int(close_wattage)) / wattage  # inverse proportion
 
     def _calc_battery_discharge(self):
-        """Approximate battery discharge per second based on the runtime model & current wattage draw
+        """Approximate battery discharge per second based on 
+        the runtime model & current wattage draw
 
         Returns:
             float: discharge per second 
@@ -100,7 +101,8 @@ class UPS(Asset, SNMPSim):
         battery_level = self.state.battery_level
         blackout = False
 
-        # keep draining battery while its level remains above 0, UPS is on and parent is down
+        # keep draining battery while its level remains above 0
+        # UPS is on and parent is down
         while battery_level > 0 and self.state.status and not parent_up():
 
             # calculate new battery level
@@ -135,7 +137,8 @@ class UPS(Asset, SNMPSim):
                 
         Args:
             parent_up(callable): indicates if the upstream power is available
-            power_up_on_charge(boolean): indicates if the asset should be powered up when min charge level is achieved
+            power_up_on_charge(boolean): indicates if the asset should be powered up
+                                         when min charge level is achieved
 
         """
 
@@ -270,6 +273,18 @@ class UPS(Asset, SNMPSim):
     @handler("AmbientDecreased", "AmbientIncreased")
     def on_ambient_updated(self, event, *args, **kwargs):
         self._state.update_temperature(7)
+
+    @handler("VoltageDecreased")
+    def on_voltage_decreased(self, event, *args, **kwargs):
+        # update output voltage if needed
+        # upsAdvOutputVoltage
+        self.state.process_voltage(kwargs["new_value"])
+
+    @handler("VoltageIncreased")
+    def on_voltage_increased(self, event, *args, **kwargs):
+        # update output voltage if needed
+        # upsAdvOutputVoltage
+        self.state.process_voltage(kwargs["new_value"])
 
     @property
     def charge_speed_factor(self):

--- a/enginecore/enginecore/state/redis_state_listener.py
+++ b/enginecore/enginecore/state/redis_state_listener.py
@@ -67,11 +67,12 @@ class StateListener(Component):
             RedisChannels.battery_conf_charge_channel,  # update charge speed (factor)
         )
 
+        # SNMPsimd channel
         self._pubsub_streams["snmp"].psubscribe(
             RedisChannels.oid_update_channel  # snmp oid updates
         )
 
-    def monitor_redis(self, pubsub_group):
+    def monitor_redis(self, pubsub_group, json_format=True):
         """Monitors redis pubsub channels for new messages & dispatches
         corresponding events to the Engine
         Args:
@@ -93,7 +94,10 @@ class StateListener(Component):
         logging.info("Received new message in channel [%s]:", channel)
         logging.info(" > %s", data)
 
-        self.fire(Event.create(channel, json.loads(data)), self._engine)
+        self.fire(
+            Event.create(channel, json.loads(data) if json_format else data),
+            self._engine,
+        )
 
     def started(self, _):
         """
@@ -103,10 +107,17 @@ class StateListener(Component):
         logging.info("Initializing pub/sub event handlers...")
 
         # timers will be monitoring new published messages every .5 seconds
-        for stream in self._pubsub_streams.values():
+        for stream_name in ["power", "thermal", "battery"]:
+            stream = self._pubsub_streams[stream_name]
             Timer(
                 0.5, Event.create("monitor_redis", pubsub_group=stream), persist=True
             ).register(self)
+
+        # configure snmp channel:
+        snmp_event = Event.create(
+            "monitor_redis", self._pubsub_streams["snmp"], json_format=False
+        )
+        Timer(0.5, snmp_event, persist=True).register(self)
 
 
 if __name__ == "__main__":

--- a/enginecore/enginecore/state/redis_state_listener.py
+++ b/enginecore/enginecore/state/redis_state_listener.py
@@ -11,7 +11,7 @@ import redis
 from enginecore.state.redis_channels import RedisChannels
 from enginecore.state.engine import Engine
 
-# TODO: fix action recorder set ambient!
+
 class StateListener(Component):
     """Top-level component that instantiates assets 
     & maps redis events to circuit events

--- a/enginecore/enginecore/state/sensor/sensor.py
+++ b/enginecore/enginecore/state/sensor/sensor.py
@@ -370,7 +370,7 @@ class Sensor:
                     self._server_key,
                     relationship={
                         "source": self.name,
-                        "target": {"attribute": "name", "value": target},
+                        "target": {"attribute": "name", "value": '"{}"'.format(target)},
                         "event": event,
                     },
                 )
@@ -474,7 +474,11 @@ class Sensor:
             rel_details = GraphReference.get_sensor_thermal_rel(
                 session,
                 self._server_key,
-                relationship={"source": self.name, "target": target, "event": event},
+                relationship={
+                    "source": self.name,
+                    "target": {"attribute": "name", "value": '"{}"'.format(target)},
+                    "event": event,
+                },
             )
 
             if rel_details:

--- a/enginecore/enginecore/tools/recorder.py
+++ b/enginecore/enginecore/tools/recorder.py
@@ -22,8 +22,8 @@ class Recorder:
         self._module = module
 
     def __call__(self, work: callable):
-        """Make an instance of recorder a callable object that can be used as a decorator
-        with functions/class methods.
+        """Make an instance of recorder a callable object that
+        can be used as a decorator with functions/class methods.
 
         Function calls will be registered by the recorder & can be replayed later on.
 
@@ -33,9 +33,11 @@ class Recorder:
             def my_action(self):
                 ...
 
-            each call to my_action() will be stored in action history of the recorder instance,
+            each call to my_action() will be stored in action
+            history of the recorder instance,
         
-            *Note* that class or instance implementing recorded action must have key attribute
+            *Note* that class or instance implementing recorded action
+            must have key attribute
         """
 
         @functools.wraps(work)
@@ -79,7 +81,8 @@ class Recorder:
         """Save actions into a json file (actions can be later loaded)
         Args:
             action_file(optional): action history will be saved in this file
-            slc(optional): range of actions to be saved, defaults to all if not specified
+            slc(optional): range of actions to be saved,
+                           defaults to all if not specified
         Example:
             Action history is saved in the following format:
             [
@@ -102,7 +105,8 @@ class Recorder:
                 },
                 {...}
             ]
-            Where "..encoded base64 bytes.." is codecs base64 encoded pickled python object
+            Where "..encoded base64 bytes.." is codecs base64
+            encoded pickled python object
         """
         serialized_actions = []
         json_pickle = lambda x: codecs.encode(pickle.dumps(x), "base64").decode()
@@ -133,13 +137,17 @@ class Recorder:
         action_file: str = "/tmp/recorder_action_file.json",
         slc=slice(None, None),
     ):
-        """load action history from a file; Note that this function clears existing actions
+        """load action history from a file;
+        Note that this function clears existing actions
+        
         Args:
-            map_key_to_state: instances are not serialized instead their keys are stored in the file;
-                              the de-serialization is key-based and must be provided with this argument
+            map_key_to_state: instances are not serialized instead their keys 
+                              are stored in the file; the de-serialization is key-based
+                              and must be provided with this argument
                               by mapping keys to python objects
             action_file(optional): action history will be saved in this file
-            slc(optional): range of actions to be loaded from a file, defaults to all if not specified
+            slc(optional): range of actions to be loaded from a file,
+                           defaults to all if not specified
         """
 
         if self._replaying:
@@ -174,7 +182,9 @@ class Recorder:
 
     def get_action_details(self, slc: slice = slice(None, None)) -> list:
         """Human-readable details on action history;
-        Note that this method "serializes" actions so they are not callable when returned.
+        Note that this method "serializes" actions 
+        so they are not callable when returned.
+        
         Args:
             slc(slice): range of actions to be returned
         Returns:
@@ -263,9 +273,12 @@ class Recorder:
 
     @classmethod
     def perform_dry_run(cls, actions: list, slc: slice = slice(None, None)):
-        """Perform replay dry run by outputting step-by-step actions (without executing them)
+        """Perform replay dry run by outputting step-by-step actions
+        (without executing them)
+
         Args:
-            actions(list): action history, must contain action "number", "work" (action itself) & "timestamp"
+            actions(list): action history, must contain action "number",
+                           "work" (action itself) & "timestamp"
             slc(slice): range of actions
         """
 

--- a/enginecore/setup.py
+++ b/enginecore/setup.py
@@ -12,6 +12,7 @@ setup(
         "neo4j-driver",
         "pysnmp",
         "libvirt-python==4.1.0",
+        "websocket-client",
     ],
     author="Seneca OSTEP & Alteeve",
     author_email="olga.belavina@senecacollege.ca",

--- a/rpm/specfiles/hold/simengine.spec
+++ b/rpm/specfiles/hold/simengine.spec
@@ -11,7 +11,7 @@ Source0: https://github.com/Seneca-CDOT/%{name}/archive/%{gittag}/%{name}-%{vers
 
 Requires(pre): shadow-utils
 BuildRequires: OpenIPMI-devel, gcc, systemd
-Requires: neo4j, cypher-shell, redis, python-neo4j-driver, python-redis, python3-libvirt, OpenIPMI, OpenIPMI-lanserv, python3-redis, python2-redis, python3-pysnmp, python3-neo4j-driver, httpd
+Requires: neo4j, cypher-shell, redis, python-neo4j-driver, python-redis, python3-libvirt, OpenIPMI, OpenIPMI-lanserv, python3-websocket-client, python3-redis, python2-redis, python3-pysnmp, python3-neo4j-driver, httpd
 
 %description
 Simengine is a hardware simulation engine that models high-availability setups.

--- a/rpm/specfiles/simengine-core.spec
+++ b/rpm/specfiles/simengine-core.spec
@@ -1,5 +1,5 @@
 Name:      simengine-core
-Version:   3.21
+Version:   3.25
 Release:   1%{?dist}
 Summary:   SimEngine - Core
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -11,7 +11,7 @@ License:   GPLv3+
 Source0: https://github.com/Seneca-CDOT/simengine/archive/%{gittag}/simengine-%{version}.tar.gz  
 
 BuildRequires: OpenIPMI-devel, gcc
-Requires: simengine-database, python3-libvirt, OpenIPMI, OpenIPMI-lanserv, python3-redis, python2-redis, python3-pysnmp, python3-neo4j-driver
+Requires: simengine-database, python3-libvirt, OpenIPMI, OpenIPMI-lanserv, python3-redis, python2-redis, python3-pysnmp, python3-neo4j-driver, python3-websocket-client
 
 %description
 Core files for SimEngine.
@@ -55,6 +55,15 @@ systemctl daemon-reload
 systemctl enable simengine-core.service --now
 
 %changelog
+* Tue Apr 30 2019 Olga Belavina <ol.belavina@gmail.com> - 3.25-1
+- new version
+
+* Mon Apr 29 2019 Olga Belavina <ol.belavina@gmail.com> - 3.24-1
+- new version
+
+* Fri Apr 26 2019 Olga Belavina <ol.belavina@gmail.com> - 3.23-1
+- new version
+
 * Fri Mar 15 2019 Chris Tyler <ctyler.fedora@gmail.com> - 3.21-1
 - new version
 

--- a/rpm/specfiles/simengine-dashboard.spec
+++ b/rpm/specfiles/simengine-dashboard.spec
@@ -1,5 +1,5 @@
 Name:      simengine-dashboard
-Version:   3.21
+Version:   3.25
 Release:   1%{?dist}
 Summary:   SimEngine - Dashboard
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -38,6 +38,15 @@ cp -fpr * %{buildroot}%{_localstatedir}/www/html
 systemctl enable httpd.service --now
 
 %changelog
+* Tue Apr 30 2019 Olga Belavina <ol.belavina@gmail.com> - 3.25-1
+- new version
+
+* Mon Apr 29 2019 Olga Belavina <ol.belavina@gmail.com> - 3.24-1
+- new version
+
+* Fri Apr 26 2019 Olga Belavina <ol.belavina@gmail.com> - 3.23-1
+- new version
+
 * Fri Mar 15 2019 Chris Tyler <ctyler.fedora@gmail.com> - 3.21-1
 - new version
 

--- a/rpm/specfiles/simengine-database.spec
+++ b/rpm/specfiles/simengine-database.spec
@@ -1,5 +1,5 @@
 Name:      simengine-database
-Version:   3.21
+Version:   3.25
 Release:   1%{?dist}
 Summary:   SimEngine - Databases
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -37,6 +37,15 @@ sleep 10
 echo "CREATE CONSTRAINT ON (n:Asset) ASSERT (n.key) IS UNIQUE;" | cypher-shell -u simengine -p simengine
 
 %changelog
+* Tue Apr 30 2019 Olga Belavina <ol.belavina@gmail.com> - 3.25-1
+- new version
+
+* Mon Apr 29 2019 Olga Belavina <ol.belavina@gmail.com> - 3.24-1
+- new version
+
+* Fri Apr 26 2019 Olga Belavina <ol.belavina@gmail.com> - 3.23-1
+- new version
+
 * Fri Mar 15 2019 Chris Tyler <ctyler.fedora@gmail.com> - 3.21-1
 - new version
 

--- a/storage-emulation-tests/guest/storcli64
+++ b/storage-emulation-tests/guest/storcli64
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 #
 # storcli64 :: connector to emulate 'storcli64' storage tool
 #              by passing args to simengine and receiving
@@ -11,25 +11,36 @@
 #
 # Chris Tyler <chris.tyler@senecacollege.ca> 2018-12-06
 
+from __future__ import print_function
+
 import json
+import time
 import sys
 import os
 
-# Step 0: set up connection to simengine via virtio-serial connection
-# Select ONE of the following two lines to use socket or pipe communication
-# simengine = open("/dev/virtio-ports/systems.cdot.simengine.storage.pipe", "r+b", 0)
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+def send_cmd(conn):
+    conn.write(str(json.dumps({"argv": sys.argv})).encode())
+    return simengine.readline()
+
+# open a connection
 simengine = open("/dev/virtio-ports/systems.cdot.simengine.storage.net", "r+b", 0)
 
-# Step 1: encapsulate command-line arguments in json and send to socket
-simengine.write(bytes(json.dumps({"argv": sys.argv}), "UTF-8"))
+# wait for the daemon running on the host to respond:
+response_msg = send_cmd(simengine)
+while not response_msg:
+    response_msg = send_cmd(simengine)
+    time.sleep(1)
 
-# Step 2: wait for one line from the other end, deserialize, and output
-# the received values
-received = json.loads(simengine.readline())
+received = json.loads(response_msg)
+
+# print out storcli64 output
 if len(received["stdout"]) > 0:
     print(received["stdout"])
 if len(received["stderr"]) > 0:
-    print(received["stderr"], file=sys.stderr)
+    eprint(received["stderr"])
 
 # End: tidy and wrap
 simengine.close()


### PR DESCRIPTION
UPS can transfer to battery for multiple reasons, this adds voltage to the list of supported options (such as brownout, highLineVoltage etc.)

From official APC docs on transfer reasons: 
```
Reason for the occurrence of the last transfer to UPS
        The variable is set to:
            - noTransfer(1) -- if there is no transfer yet.

            - highLineVoltage(2) -- if the transfer to battery is caused
            by an over voltage greater than the high transfer voltage.
            
            - brownout(3) -- if the duration of the outage is greater than
            five seconds and the line voltage is between 40% of the
            rated output voltage and the low transfer voltage.
            
            - blackout(4) -- if the duration of the outage is greater than five
            seconds and the line voltage is between 40% of the rated
            output voltage and ground.
            
            - smallMomentarySag(5) -- if the duration of the outage is less
            than five seconds and the line voltage is between 40% of the
            rated output voltage and the low transfer voltage.
            
            - deepMomentarySag(6) -- if the duration of the outage is less
            than five seconds and the line voltage is between 40% of the
            rated output voltage and ground.  The variable is set to
            
            - smallMomentarySpike(7) -- if the line failure is caused by a
            rate of change of input voltage less than ten volts per cycle.
            
            - largeMomentarySpike(8) -- if the line failure is caused by
            a rate of change of input voltage greater than ten volts per cycle.
            
            - selfTest(9) -- if the UPS was commanded to do a self test.
            
            - rateOfVoltageChange(10) -- if the failure is due to the rate of change of
            the line voltage.
```