### PR TITLE
Closes #124; include UPS high precision voltage in voltage simulation

### DIFF
--- a/enginecore/enginecore/model/presets/apc_ups.json
+++ b/enginecore/enginecore/model/presets/apc_ups.json
@@ -122,7 +122,7 @@
             "dataType": 66,
             "defaultValue": 0
         },
-        "AdvHighPrecOutputVoltage": {
+        "HighPrecOutputVoltage": {
             "OID": "1.3.6.1.4.1.318.1.1.1.4.3.1.0",
             "dataType": 66,
             "defaultValue": 0
@@ -132,7 +132,7 @@
             "dataType": 66,
             "defaultValue": 0
         },
-        "AdvHighPrecInputLineVoltage": {
+        "HighPrecInputLineVoltage": {
             "OID": "1.3.6.1.4.1.318.1.1.1.3.3.1.0",
             "dataType": 66,
             "defaultValue": 0

--- a/enginecore/enginecore/model/presets/apc_ups.json
+++ b/enginecore/enginecore/model/presets/apc_ups.json
@@ -122,8 +122,18 @@
             "dataType": 66,
             "defaultValue": 0
         },
+        "AdvHighPrecOutputVoltage": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.4.3.1.0",
+            "dataType": 66,
+            "defaultValue": 0
+        },
         "AdvInputLineVoltage": {
             "OID": "1.3.6.1.4.1.318.1.1.1.3.2.1.0",
+            "dataType": 66,
+            "defaultValue": 0
+        },
+        "AdvHighPrecInputLineVoltage": {
+            "OID": "1.3.6.1.4.1.318.1.1.1.3.3.1.0",
             "dataType": 66,
             "defaultValue": 0
         },

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -201,7 +201,7 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         oid_out_adv = self.get_oid_by_name("AdvOutputVoltage")
         oid_out_high_prec = self.get_oid_by_name("HighPrecOutputVoltage")
 
-        if not oid_in_adv or not oid_out_adv:
+        if not oid_in_adv or not oid_in_high_prec or not oid_out_adv or not oid_out_high_prec:
             raise ValueError("UPS doesn't support voltage OIDs!")
 
         oid_voltage_value = snmp_data_types.Gauge32(int(voltage))

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -12,6 +12,7 @@ from enginecore.model.graph_reference import GraphReference
 from enginecore.state.redis_channels import RedisChannels
 import enginecore.state.api as state_api
 
+from enginecore.tools.utils import convert_voltage_to_high_prec
 
 class StateManager(state_api.IStateManager, state_api.ISystemEnvironment):
     """Exposes private logic to assets"""
@@ -196,7 +197,9 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         """
 
         oid_in_adv = self.get_oid_by_name("AdvInputLineVoltage")
+        oid_in_adv_hp = self.get_oid_by_name("AdvHighPrecInputLineVoltage")
         oid_out_adv = self.get_oid_by_name("AdvOutputVoltage")
+        oid_out_adv_hp = self.get_oid_by_name("AdvHighPrecOutputVoltage")
 
         if not oid_in_adv or not oid_out_adv:
             raise ValueError("UPS doesn't support voltage OIDs!")
@@ -205,6 +208,7 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
 
         # update input OID parameter
         self._update_oid_value(oid_in_adv, oid_voltage_value)
+        self._update_oid_value(oid_in_adv_hp, convert_voltage_to_high_prec(oid_voltage_value))
 
         # retrieve thresholds:
         oid_high_th = self.get_oid_by_name("AdvConfigHighTransferVolt")
@@ -213,7 +217,7 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         # update output OID value if thresholds are not supported
         if not oid_high_th or not oid_low_th:
             self._update_oid_value(oid_out_adv, oid_voltage_value)
-
+            self._update_oid_value(oid_out_adv_hp, convert_voltage_to_high_prec(oid_voltage_value))
             return False, None
 
         high_th = int(self.get_oid_value(oid_high_th))
@@ -222,6 +226,7 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         # new voltage value is within the threasholds
         if low_th < voltage < high_th:
             self._update_oid_value(oid_out_adv, oid_voltage_value)
+            self._update_oid_value(oid_out_adv_hp, convert_voltage_to_high_prec(oid_voltage_value))
             return False, None
 
         # new voltage should cause line transfer:

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -197,9 +197,9 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         """
 
         oid_in_adv = self.get_oid_by_name("AdvInputLineVoltage")
-        oid_in_adv_hp = self.get_oid_by_name("AdvHighPrecInputLineVoltage")
+        oid_in_high_prec = self.get_oid_by_name("HighPrecInputLineVoltage")
         oid_out_adv = self.get_oid_by_name("AdvOutputVoltage")
-        oid_out_adv_hp = self.get_oid_by_name("AdvHighPrecOutputVoltage")
+        oid_out_high_prec = self.get_oid_by_name("HighPrecOutputVoltage")
 
         if not oid_in_adv or not oid_out_adv:
             raise ValueError("UPS doesn't support voltage OIDs!")
@@ -208,7 +208,8 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
 
         # update input OID parameter
         self._update_oid_value(oid_in_adv, oid_voltage_value)
-        self._update_oid_value(oid_in_adv_hp, convert_voltage_to_high_prec(oid_voltage_value))
+        self._update_oid_value(
+            oid_in_high_prec, convert_voltage_to_high_prec(oid_voltage_value))
 
         # retrieve thresholds:
         oid_high_th = self.get_oid_by_name("AdvConfigHighTransferVolt")
@@ -217,7 +218,8 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         # update output OID value if thresholds are not supported
         if not oid_high_th or not oid_low_th:
             self._update_oid_value(oid_out_adv, oid_voltage_value)
-            self._update_oid_value(oid_out_adv_hp, convert_voltage_to_high_prec(oid_voltage_value))
+            self._update_oid_value(
+                oid_out_high_prec, convert_voltage_to_high_prec(oid_voltage_value))
             return False, None
 
         high_th = int(self.get_oid_value(oid_high_th))
@@ -226,7 +228,8 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         # new voltage value is within the threasholds
         if low_th < voltage < high_th:
             self._update_oid_value(oid_out_adv, oid_voltage_value)
-            self._update_oid_value(oid_out_adv_hp, convert_voltage_to_high_prec(oid_voltage_value))
+            self._update_oid_value(
+                oid_out_high_prec, convert_voltage_to_high_prec(oid_voltage_value))
             return False, None
 
         # new voltage should cause line transfer:

--- a/enginecore/enginecore/state/hardware/internal_state.py
+++ b/enginecore/enginecore/state/hardware/internal_state.py
@@ -14,6 +14,7 @@ import enginecore.state.api as state_api
 
 from enginecore.tools.utils import convert_voltage_to_high_prec
 
+
 class StateManager(state_api.IStateManager, state_api.ISystemEnvironment):
     """Exposes private logic to assets"""
 
@@ -201,7 +202,12 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         oid_out_adv = self.get_oid_by_name("AdvOutputVoltage")
         oid_out_high_prec = self.get_oid_by_name("HighPrecOutputVoltage")
 
-        if not oid_in_adv or not oid_in_high_prec or not oid_out_adv or not oid_out_high_prec:
+        if (
+            not oid_in_adv
+            or not oid_in_high_prec
+            or not oid_out_adv
+            or not oid_out_high_prec
+        ):
             raise ValueError("UPS doesn't support voltage OIDs!")
 
         oid_voltage_value = snmp_data_types.Gauge32(int(voltage))
@@ -209,7 +215,8 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         # update input OID parameter
         self._update_oid_value(oid_in_adv, oid_voltage_value)
         self._update_oid_value(
-            oid_in_high_prec, convert_voltage_to_high_prec(oid_voltage_value))
+            oid_in_high_prec, convert_voltage_to_high_prec(oid_voltage_value)
+        )
 
         # retrieve thresholds:
         oid_high_th = self.get_oid_by_name("AdvConfigHighTransferVolt")
@@ -219,7 +226,8 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         if not oid_high_th or not oid_low_th:
             self._update_oid_value(oid_out_adv, oid_voltage_value)
             self._update_oid_value(
-                oid_out_high_prec, convert_voltage_to_high_prec(oid_voltage_value))
+                oid_out_high_prec, convert_voltage_to_high_prec(oid_voltage_value)
+            )
             return False, None
 
         high_th = int(self.get_oid_value(oid_high_th))
@@ -229,7 +237,8 @@ class UPSStateManager(state_api.IUPSStateManager, StateManager):
         if low_th < voltage < high_th:
             self._update_oid_value(oid_out_adv, oid_voltage_value)
             self._update_oid_value(
-                oid_out_high_prec, convert_voltage_to_high_prec(oid_voltage_value))
+                oid_out_high_prec, convert_voltage_to_high_prec(oid_voltage_value)
+            )
             return False, None
 
         # new voltage should cause line transfer:

--- a/enginecore/enginecore/tools/utils.py
+++ b/enginecore/enginecore/tools/utils.py
@@ -22,6 +22,7 @@ def format_as_redis_key(key, oid, key_formatted=True):
 
     return key_and_oid
 
+
 def convert_voltage_to_high_prec(voltage_value):
     """Convert voltage value into high precision.
     Args:

--- a/enginecore/enginecore/tools/utils.py
+++ b/enginecore/enginecore/tools/utils.py
@@ -21,3 +21,13 @@ def format_as_redis_key(key, oid, key_formatted=True):
     key_and_oid += (oid_digits[-1]).rjust(10, " ")
 
     return key_and_oid
+
+def convert_voltage_to_high_prec(voltage_value):
+    """Convert voltage value into high precision.
+    Args:
+        voltage_value(int): voltage value in vAC
+    Returns:
+        int: high precision voltage
+    """
+
+    return voltage_value * 10

--- a/rpm/specfiles/simengine-core.spec
+++ b/rpm/specfiles/simengine-core.spec
@@ -1,5 +1,5 @@
 Name:      simengine-core
-Version:   3.27
+Version:   3.28
 Release:   1%{?dist}
 Summary:   SimEngine - Core
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -55,6 +55,9 @@ systemctl daemon-reload
 systemctl enable simengine-core.service --now
 
 %changelog
+* Mon Dec 02 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.28-1
+- new version
+
 * Thu Oct 03 2019 Chris Tyler <ctyler.fedora@gmail.com> - 3.27-1
 - new version
 

--- a/rpm/specfiles/simengine-dashboard.spec
+++ b/rpm/specfiles/simengine-dashboard.spec
@@ -1,5 +1,5 @@
 Name:      simengine-dashboard
-Version:   3.27
+Version:   3.28
 Release:   1%{?dist}
 Summary:   SimEngine - Dashboard
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -38,6 +38,9 @@ cp -fpr * %{buildroot}%{_localstatedir}/www/html
 systemctl enable httpd.service --now
 
 %changelog
+* Mon Dec 02 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.28-1
+- new version
+
 * Thu Oct 03 2019 Chris Tyler <ctyler.fedora@gmail.com> - 3.27-1
 - new version
 

--- a/rpm/specfiles/simengine-database.spec
+++ b/rpm/specfiles/simengine-database.spec
@@ -1,5 +1,5 @@
 Name:      simengine-database
-Version:   3.27
+Version:   3.28
 Release:   1%{?dist}
 Summary:   SimEngine - Databases
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -37,6 +37,9 @@ sleep 10
 echo "CREATE CONSTRAINT ON (n:Asset) ASSERT (n.key) IS UNIQUE;" | cypher-shell -u simengine -p simengine
 
 %changelog
+* Mon Dec 02 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.28-1
+- new version
+
 * Thu Oct 03 2019 Chris Tyler <ctyler.fedora@gmail.com> - 3.27-1
 - new version
 


### PR DESCRIPTION
As per #124, SimEngine is only modifying the advanced input and output voltages. This PR adds high precision input and output voltages to the voltage simulation.