### PR TITLE
Fix ipmi_sim crashing on fgets

### DIFF
--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -78,9 +78,12 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
   if (fp == NULL)
   {
     sys->log(sys, OS_ERROR, NULL, "Failed to fetch asset status; CAUSE: %s", strerror(errno));
-
-    // using the max of an unsigned char for error
-    *val = 255;
+    // according to the popen docs, the only time it would return NULL is when
+    // 1) `fork` call fails
+    // 2) `pipe` call fails
+    // 3) unable to allocated memory
+    // therefore, this is likely a severe error; stop the simulator
+    exit(1);
   }
   else
   {
@@ -94,6 +97,8 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
     if (pclose(fp) < 0)
     {
       sys->log(sys, OS_ERROR, NULL, "Failed to close file handle; CAUSE: %s", strerror(errno));
+      // failing to clean up is most likely a severe error; stop the simulator
+      exit(1);
     }
   }
 

--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -77,7 +77,7 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
   FILE *fp = popen(power_cmd, "r");
   if (fp == NULL)
   {
-    sys->log(sys, DEBUG, NULL, "Failed to fetch asset status; CAUSE: %x", errno);
+    sys->log(sys, OS_ERROR, NULL, "Failed to fetch asset status; CAUSE: %s", strerror(errno));
 
     // using the max of an unsigned char for error
     *val = 255;
@@ -93,7 +93,7 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
 
     if (pclose(fp) < 0)
     {
-      sys->log(sys, DEBUG, NULL, "Failed to close file handle; CAUSE: %x", errno);
+      sys->log(sys, OS_ERROR, NULL, "Failed to close file handle; CAUSE: %s", strerror(errno));
     }
   }
 

--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -78,18 +78,23 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
   if (fp == NULL)
   {
     sys->log(sys, DEBUG, NULL, "Failed to fetch asset status; CAUSE: %x", errno);
-  }
 
-  // get the command result
-  char result[24] = {0x0};
-  while (fgets(result, sizeof(result), fp) != NULL)
-  {
-    *val = atoi(result);
+    // using the max of an unsigned char for error
+    *val = 255;
   }
-
-  if (pclose(fp) < 0)
+  else
   {
-    sys->log(sys, DEBUG, NULL, "Failed to close file handle; CAUSE: %x", errno);
+    // get the command result
+    char result[24] = {0x0};
+    while (fgets(result, sizeof(result), fp) != NULL)
+    {
+      *val = atoi(result);
+    }
+
+    if (pclose(fp) < 0)
+    {
+      sys->log(sys, DEBUG, NULL, "Failed to close file handle; CAUSE: %x", errno);
+    }
   }
 
   return 0;

--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -87,6 +87,11 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
     *val = atoi(result);
   }
 
+  if (pclose(fp) < 0)
+  {
+    sys->log(sys, DEBUG, NULL, "Failed to close file handle; CAUSE: %x", errno);
+  }
+
   return 0;
 }
 

--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -77,7 +77,7 @@ bmc_get_chassis_control(lmc_data_t *mc, int op, unsigned char *val,
   FILE *fp = popen(power_cmd, "r");
   if (fp == NULL)
   {
-    sys->log(sys, DEBUG, NULL, "Failed to fetch asset status!");
+    sys->log(sys, DEBUG, NULL, "Failed to fetch asset status; CAUSE: %x", errno);
   }
 
   // get the command result

--- a/rpm/specfiles/simengine-core.spec
+++ b/rpm/specfiles/simengine-core.spec
@@ -1,5 +1,5 @@
 Name:      simengine-core
-Version:   3.28
+Version:   3.29
 Release:   1%{?dist}
 Summary:   SimEngine - Core
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -55,6 +55,9 @@ systemctl daemon-reload
 systemctl enable simengine-core.service --now
 
 %changelog
+* Wed Dec 11 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.29-1
+- new version
+
 * Mon Dec 02 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.28-1
 - new version
 

--- a/rpm/specfiles/simengine-dashboard.spec
+++ b/rpm/specfiles/simengine-dashboard.spec
@@ -1,5 +1,5 @@
 Name:      simengine-dashboard
-Version:   3.28
+Version:   3.29
 Release:   1%{?dist}
 Summary:   SimEngine - Dashboard
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -38,6 +38,9 @@ cp -fpr * %{buildroot}%{_localstatedir}/www/html
 systemctl enable httpd.service --now
 
 %changelog
+* Wed Dec 11 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.29-1
+- new version
+
 * Mon Dec 02 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.28-1
 - new version
 

--- a/rpm/specfiles/simengine-database.spec
+++ b/rpm/specfiles/simengine-database.spec
@@ -1,5 +1,5 @@
 Name:      simengine-database
-Version:   3.28
+Version:   3.29
 Release:   1%{?dist}
 Summary:   SimEngine - Databases
 URL:       https://github.com/Seneca-CDOT/simengine
@@ -37,6 +37,9 @@ sleep 10
 echo "CREATE CONSTRAINT ON (n:Asset) ASSERT (n.key) IS UNIQUE;" | cypher-shell -u simengine -p simengine
 
 %changelog
+* Wed Dec 11 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.29-1
+- new version
+
 * Mon Dec 02 2019 Yanhao Lei <ynho.li.aa.e@gmail.com> - 3.28-1
 - new version
 


### PR DESCRIPTION
The cause of the crash is streams opened by `popen` is never closed. When the number of opened streams hit the limit set by the OS (`ulimit -n`), it would set `errorno` to `18` (which is "too many files opened") and return NULL. The crash happens when `fgets` is called with the NULL received from `popen`.

The majority of the fix is to clean up the streams with `pclose`.

Closes #127.