### PR TITLE
Add PSU fan RPM simulation to all power-related cases

### DIFF
--- a/enginecore/enginecore/model/presets/sensors.json
+++ b/enginecore/enginecore/model/presets/sensors.json
@@ -65,7 +65,7 @@
         "sensorDefinitions": [
             {
                 "thresholds": {
-                    "lnc": 1000
+                    "lnc": 600
                 },
                 "defaultValue": 1000,
                 "name": "PSU{index} Fan",
@@ -73,7 +73,7 @@
             },
             {
                 "thresholds": {
-                    "lnc": 1000
+                    "lnc": 600
                 },
                 "defaultValue": 1000,
                 "name": "PSU{index} Fan",

--- a/enginecore/enginecore/state/hardware/server_asset.py
+++ b/enginecore/enginecore/state/hardware/server_asset.py
@@ -505,7 +505,7 @@ class PSU(StaticAsset):
         return_value = None
 
         try:
-            if type(psu_sensor[sensor_prop_key]).__name__ == "function":
+            if callable(psu_sensor[sensor_prop_key]):
                 # Spread args as arguments for function on the sensor
                 return_value = psu_sensor[sensor_prop_key](*args)
             else:

--- a/enginecore/enginecore/state/hardware/server_asset.py
+++ b/enginecore/enginecore/state/hardware/server_asset.py
@@ -518,11 +518,11 @@ class PSU(StaticAsset):
             psu_current.sensor_value = int(load)
 
         if "psuPower" in self._psu_sensor_names:
-            psu_current = self._sensor_repo.get_sensor_by_name(
+            psu_power = self._sensor_repo.get_sensor_by_name(
                 self._psu_sensor_names["psuPower"]
             )
 
-            psu_current.sensor_value = int(load) * 10
+            psu_power.sensor_value = int(load) * 10
 
     def _get_fan_sensor(self):
         """Get psu fan sensor, returns None if not supported"""

--- a/enginecore/enginecore/state/hardware/server_asset.py
+++ b/enginecore/enginecore/state/hardware/server_asset.py
@@ -492,7 +492,7 @@ class PSU(StaticAsset):
         """
         psu_sensor = None
 
-        if self._state.supports_bmc and sensor_name in self._psu_sensor_names:
+        if (self._state.supports_bmc) and (sensor_name in self._psu_sensor_names):
             psu_sensor = self._sensor_repo.get_sensor_by_name(
                 self._psu_sensor_names[sensor_name]
             )

--- a/enginecore/enginecore/state/hardware/server_asset.py
+++ b/enginecore/enginecore/state/hardware/server_asset.py
@@ -499,18 +499,20 @@ class PSU(StaticAsset):
 
         return psu_sensor
 
-    def _exec_on_psu_sensor(self, sensor_name, sensor_prop_key, *args):
+    def _exec_on_psu_sensor(self, sensor_name, sensor_attribute_key, *args):
         """Either execute a function or set the property of the given sensor."""
         psu_sensor = self._get_psu_sensor(sensor_name)
         return_value = None
 
         try:
-            if callable(psu_sensor[sensor_prop_key]):
+            psu_sensor_attribute = getattr(psu_sensor, sensor_attribute_key, None)
+
+            if callable(psu_sensor_attribute):
                 # Spread args as arguments for function on the sensor
-                return_value = psu_sensor[sensor_prop_key](*args)
+                return_value = psu_sensor_attribute(*args)
             else:
                 # If setting the sensor's property, use the 0th argument
-                psu_sensor[sensor_prop_key] = args[0]
+                setattr(psu_sensor, sensor_attribute_key, args[0])
         except AttributeError:
             # Not a severe error because sensors not found can be ignored
             logger.debug("PSU sensor named [%s] not found.", sensor_name, exc_info=1)

--- a/enginecore/enginecore/state/hardware/server_asset.py
+++ b/enginecore/enginecore/state/hardware/server_asset.py
@@ -524,6 +524,13 @@ class PSU(StaticAsset):
 
             psu_power.sensor_value = int(load) * 10
 
+        if "psuFan" in self._psu_sensor_names:
+            psu_fan = self._sensor_repo.get_sensor_by_name(
+                self._psu_sensor_names["psuFan"]
+            )
+
+            psu_fan.sensor_value = int(load) * 1000
+
     def _get_fan_sensor(self):
         """Get psu fan sensor, returns None if not supported"""
         if not self._state.supports_bmc:


### PR DESCRIPTION
Power-related cases include:
1. Power on the PSU
2. Power off the PSU
3. Cutting input voltage to the PSU
4. Restoring input voltage to the PSU

This PR also includes refactoring of the functions used to access the PSU sensors.

**The `_exec_on_psu_sensor` function should be reviewed with care.** The intention for implementing this function is to eliminate the need to check whether the sensor exists before accessing its properties or executing its functions.

Closes #129. 