### PR TITLE
Empty model status error fix 

### DIFF
--- a/enginecore/enginecore/cli/status.py
+++ b/enginecore/enginecore/cli/status.py
@@ -51,12 +51,16 @@ class BCOLORS:
 
 
 def status_table_format(assets, stdscr=False):
-    """ Display status in a table format 
+    """Display status in a table format
     Args:
         assets (dict): list of assets supported by the system
         stdscr (optional): default window return by initscr(),
                            status_table_format uses print if omitted
     """
+    # Catches empty model and doesnt throw error
+    if assets is None:
+        print("Table is empty")
+        return
 
     # format headers
     headers = ["Key", "Type", "Status", "Children", "Load"]
@@ -105,7 +109,7 @@ def status_table_format(assets, stdscr=False):
 
 
 def get_status(**kwargs):
-    """ Retrieve power states of the assets 
+    """Retrieve power states of the assets
     Args:
         **kwargs: Command line options
     """


### PR DESCRIPTION
Error no longer shows up when you run simengine-cli status with an empty model.
Before it would give a TypeError now it just tells you that the model is empty with no error.
Added if statement to catch the error 

Closes #83 