### PR TITLE
Resolve compatibility of `haos_extend.c` with latest OpenIPMI version

### DIFF
--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -23,7 +23,12 @@
 
 #include <OpenIPMI/ipmi_msgbits.h>
 #include <OpenIPMI/ipmi_bits.h>
-#include <OpenIPMI/serv.h>
+
+#ifdef INCLUDE_MCSERV_H
+  #include <OpenIPMI/mcserv.h>
+#else
+  #include <OpenIPMI/serv.h>
+#endif
 
 #define PVERSION "0.0.0"
 

--- a/enginecore/ipmi_sim/haos_extend.c
+++ b/enginecore/ipmi_sim/haos_extend.c
@@ -24,7 +24,7 @@
 #include <OpenIPMI/ipmi_msgbits.h>
 #include <OpenIPMI/ipmi_bits.h>
 
-#ifdef INCLUDE_MCSERV_H
+#ifdef OPENIPMI_POST_2_0_30
   #include <OpenIPMI/mcserv.h>
 #else
   #include <OpenIPMI/serv.h>
@@ -181,7 +181,11 @@ int ipmi_sim_module_init(sys_data_t *sys, const char *options)
 
   free(initstr);
 
+#ifdef OPENIPMI_POST_2_0_30
+  rv = is_mc_alloc_unconfigured(sys, 0x20, &bmc_mc);
+#else
   rv = ipmi_mc_alloc_unconfigured(sys, 0x20, &bmc_mc);
+#endif
 
   if (rv)
   {

--- a/rpm/specfiles/simengine-core.spec
+++ b/rpm/specfiles/simengine-core.spec
@@ -7,12 +7,11 @@ License:   GPLv3+
 
 %global gittag %{version}
 %global selected_libdir /usr/lib64
-%global openipmi_version 2.0.28
 
 Source0: https://github.com/Seneca-CDOT/simengine/archive/%{gittag}/simengine-%{version}.tar.gz  
 
-BuildRequires: OpenIPMI-devel = %{openipmi_version}, gcc
-Requires: simengine-database, python3-libvirt, OpenIPMI = %{openipmi_version}, OpenIPMI-lanserv = %{openipmi_version}, python3-redis, python3-pysnmp, python3-neo4j-driver, python3-websocket-client
+BuildRequires: OpenIPMI-devel, gcc
+Requires: simengine-database, python3-libvirt, OpenIPMI, OpenIPMI-lanserv, python3-redis, python3-pysnmp, python3-neo4j-driver, python3-websocket-client
 
 %description
 Core files for SimEngine.

--- a/rpm/specfiles/simengine-core.spec
+++ b/rpm/specfiles/simengine-core.spec
@@ -26,12 +26,12 @@ Core files for SimEngine.
 
 %build
 openipmi_version=$(rpm -q --qf "%%{VERSION}" OpenIPMI-devel)
-define_include_mcserv_h=$([[ "$openipmi_version" > "2.0.30" ]] && printf "%s" "-D INCLUDE_MCSERV_H")
+define_openipmi_post_2_0_30=$([[ "$openipmi_version" > "2.0.30" ]] && printf "%s" "-D OPENIPMI_POST_2_0_30")
 gcc \
     -shared \
     -o %{_builddir}/simengine-%{version}/haos_extend.so \
     -fPIC \
-    $define_include_mcserv_h \
+    $define_openipmi_post_2_0_30 \
     %{_builddir}/simengine-%{version}/enginecore/ipmi_sim/haos_extend.c
 
 %install

--- a/rpm/specfiles/simengine-core.spec
+++ b/rpm/specfiles/simengine-core.spec
@@ -25,7 +25,14 @@ Core files for SimEngine.
 %autosetup -n simengine-%{version}
 
 %build
-gcc -shared -o %{_builddir}/simengine-%{version}/haos_extend.so -fPIC %{_builddir}/simengine-%{version}/enginecore/ipmi_sim/haos_extend.c
+openipmi_version=$(rpm -q --qf "%%{VERSION}" OpenIPMI-devel)
+define_include_mcserv_h=$([[ "$openipmi_version" > "2.0.30" ]] && printf "%s" "-D INCLUDE_MCSERV_H")
+gcc \
+    -shared \
+    -o %{_builddir}/simengine-%{version}/haos_extend.so \
+    -fPIC \
+    $define_include_mcserv_h \
+    %{_builddir}/simengine-%{version}/enginecore/ipmi_sim/haos_extend.c
 
 %install
 mkdir -p %{buildroot}%{_datadir}/simengine/


### PR DESCRIPTION
https://github.com/Seneca-CDOT/simengine/issues/150#issuecomment-889545294 outlines the 2 breaking changes from OpenIPMI version `2.0.30` to `2.0.31`.

The solution provided by this PR includes:
1. Remove OpenIPMI version restriction (to `2.0.28`)
2. Auto-detect OpenIPMI version during RPM `%build` phase
3. Use the appropriate header (`mcserv.h` versus `serv.h`) and function (`is_mc_alloc_unconfigured` versus `ipmi_mc_alloc_unconfigured`) based on the version of OpenIPMI used to build the shared object.

Note that a `warning: implicit declaration of function 'is_mc_alloc_unconfigured' ..` will appear during build due to the reason specified in point 2 of https://github.com/Seneca-CDOT/simengine/issues/150#issuecomment-889545294. This warning can be ignored because `ipmi_sim` ran without issues; confirmed during testing that the function was actually called and returned as expected.

A reminder to bump the version **after** merging to master/main.

Closes #150 