### PR TITLE
Fixed Incorrect UPS load on GUI after powering down AC main

### DIFF
--- a/enginecore/enginecore/state/net/ws_server.py
+++ b/enginecore/enginecore/state/net/ws_server.py
@@ -359,8 +359,6 @@ class WebSocket(Component):
         client_request = ServerToClientRequests.asset_upd
         payload = {"key": event.asset.key}
 
-        if not event.load.unchanged():
-            payload["load"] = event.load.new
         if not event.state.unchanged():
             payload["status"] = event.state.new
 


### PR DESCRIPTION
#163 Removed two lines of code within method on_asset_power_change checking for load change, triggering an extra request to the GUI, causing the issue