### PR TITLE
Fixed Incorrect UPS / Outlet load on GUI when powering down / up while on battery

### DIFF
--- a/enginecore/enginecore/state/engine/events.py
+++ b/enginecore/enginecore/state/engine/events.py
@@ -408,6 +408,7 @@ class AssetPowerEvent(EngineEvent):
     def calc_load_from_volt(self):
         """Sets load change based off old,  new load and asset's
         power consumption"""
+        logger.info("calc_load_from_volt: out_volt.old: %s out_volt.new: %s", self.out_volt.old, self.out_volt.new)
         calc_load = functools.partial(AssetPowerEvent.calculate_load, self._asset.state)
         self._load = EventDataPair(
             *(calc_load(volt) for volt in [self.out_volt.old, self.out_volt.new])
@@ -415,7 +416,6 @@ class AssetPowerEvent(EngineEvent):
 
     @staticmethod
     def calculate_load(state, voltage):
-        logger.info("calculate_load: state: %s voltage: %s", state, voltage)
         """Calculate asset load"""
         return state.power_consumption / voltage if voltage else 0
 

--- a/enginecore/enginecore/state/engine/events.py
+++ b/enginecore/enginecore/state/engine/events.py
@@ -408,7 +408,6 @@ class AssetPowerEvent(EngineEvent):
     def calc_load_from_volt(self):
         """Sets load change based off old,  new load and asset's
         power consumption"""
-        logger.info("calc_load_from_volt: out_volt.old: %s out_volt.new: %s", self.out_volt.old, self.out_volt.new)
         calc_load = functools.partial(AssetPowerEvent.calculate_load, self._asset.state)
         self._load = EventDataPair(
             *(calc_load(volt) for volt in [self.out_volt.old, self.out_volt.new])

--- a/enginecore/enginecore/state/engine/events.py
+++ b/enginecore/enginecore/state/engine/events.py
@@ -10,6 +10,7 @@ from circuits import Event
 
 logger = logging.getLogger(__name__)
 
+
 class EventDataPair:
     """A tiny utility that helps keep track of value changes due to some event
     (old & new values).
@@ -574,7 +575,7 @@ class LoadEvent(EngineEvent):
     @property
     def ups_on_battery(self):
         return self._ups_on_battery
-        
+
     def __str__(self):
         return self._load.__str__()
 
@@ -616,6 +617,7 @@ class AssetLoadEvent(LoadEvent):
 
 class ChildLoadEvent(LoadEvent):
     """Event at child load changes"""
+
     success = True
 
     def get_next_load_event(self, target_asset):

--- a/enginecore/enginecore/state/engine/events.py
+++ b/enginecore/enginecore/state/engine/events.py
@@ -561,12 +561,17 @@ class LoadEvent(EngineEvent):
             raise KeyError("Needs arguments: " + ",".join(required_args))
 
         self._load = EventDataPair(kwargs["old_load"], kwargs["new_load"])
+        self._ups_on_battery = None
 
     @property
     def load(self):
         """Get load update (old/new values) associated with this event"""
         return self._load
 
+    @property
+    def ups_on_battery(self):
+        return self._ups_on_battery
+        
     def __str__(self):
         return self._load.__str__()
 
@@ -614,6 +619,7 @@ class ChildLoadEvent(LoadEvent):
         """Get next asset event resulted from
         load changes of the child asset
         """
+        logger.info("ChildLoadEvent: get_next_load_event: target_asset: %s", target_asset)
         return AssetLoadEvent(
             asset=target_asset,
             power_iter=self.power_iter,

--- a/enginecore/enginecore/state/engine/events.py
+++ b/enginecore/enginecore/state/engine/events.py
@@ -5,8 +5,10 @@ Whereas assets return events that had happened to them (e.g. if asset load was u
 due to voltage change etc.)
 """
 import functools
+import logging
 from circuits import Event
 
+logger = logging.getLogger(__name__)
 
 class EventDataPair:
     """A tiny utility that helps keep track of value changes due to some event
@@ -413,6 +415,7 @@ class AssetPowerEvent(EngineEvent):
 
     @staticmethod
     def calculate_load(state, voltage):
+        logger.info("calculate_load: state: %s voltage: %s", state, voltage)
         """Calculate asset load"""
         return state.power_consumption / voltage if voltage else 0
 

--- a/enginecore/enginecore/state/engine/events.py
+++ b/enginecore/enginecore/state/engine/events.py
@@ -555,7 +555,6 @@ class LoadEvent(EngineEvent):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        logger.info("LoadEvent: ___init___")
         required_args = ["old_load", "new_load"]
 
         if not all(r_arg in kwargs for r_arg in required_args):
@@ -585,7 +584,6 @@ class AssetLoadEvent(LoadEvent):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        logger.info("AssetLoadEvent: ___init___")
         if "asset" not in kwargs or not kwargs["asset"]:
             raise KeyError("Needs arguments: asset")
 
@@ -595,7 +593,6 @@ class AssetLoadEvent(LoadEvent):
     def get_next_load_event(self):
         """Get next load event that can be dispatched against asset powering this
         device"""
-        logger.info("AssetLoadEvent: get_next_load_event: ChildLoadDownEvent VS ChildLoadUpEvent")
         return (ChildLoadDownEvent if self._load.difference < 0 else ChildLoadUpEvent)(
             power_iter=self.power_iter,
             branch=self._branch,

--- a/enginecore/enginecore/state/hardware/asset.py
+++ b/enginecore/enginecore/state/hardware/asset.py
@@ -158,13 +158,14 @@ class Asset(Component):
             AssetLoadEvent: contains load update details for this asset
         """
         asset_load_event = event.get_next_load_event(self)
-        new_load = asset_load_event.load.old + event.load.difference
 
-        self._update_load(new_load)
-        asset_load_event.load.new = new_load
-        if asset_load_event._asset.key == 1:
-            logger.info("ASSET.PY LOAD EVENT: %s", asset_load_event)
-            logger.info("ups status %s", asset_load_event.ups_on_battery)
+        if asset_load_event.ups_on_battery:
+            new_load = asset_load_event.load.old
+            asset_load_event.load.new = new_load
+        else:
+            new_load = asset_load_event.load.old + event.load.difference
+            asset_load_event.load.new = new_load
+            self._update_load(new_load)
 
         return asset_load_event
 

--- a/enginecore/enginecore/state/hardware/asset.py
+++ b/enginecore/enginecore/state/hardware/asset.py
@@ -162,6 +162,10 @@ class Asset(Component):
 
         self._update_load(new_load)
         asset_load_event.load.new = new_load
+        if asset_load_event._asset.key == 1:
+            logger.info("ASSET.PY LOAD EVENT: %s", asset_load_event)
+            logger.info("ups status %s", asset_load_event.ups_on_battery)
+
         return asset_load_event
 
     @handler("AmbientUpEvent", "AmbientDownEvent")

--- a/enginecore/enginecore/state/hardware/asset.py
+++ b/enginecore/enginecore/state/hardware/asset.py
@@ -159,13 +159,9 @@ class Asset(Component):
         """
         asset_load_event = event.get_next_load_event(self)
 
-        if asset_load_event.ups_on_battery:
-            new_load = asset_load_event.load.old
-            asset_load_event.load.new = new_load
-        else:
-            new_load = asset_load_event.load.old + event.load.difference
-            asset_load_event.load.new = new_load
-            self._update_load(new_load)
+        new_load = asset_load_event.load.old + event.load.difference
+        asset_load_event.load.new = new_load
+        self._update_load(new_load)
 
         return asset_load_event
 

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -341,6 +341,7 @@ class UPS(Asset, SNMPSim):
         asset_load_event = event.get_next_load_event(self)
         self._update_load(asset_load_event.load.old + event.load.difference)
 
+        logger.info("on_child_load_update: asset_load_event: %s", asset_load_event)
         # ensure that load doesn't change for the parent
         asset_load_event.load.new = asset_load_event.load.old
         return asset_load_event

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -338,13 +338,11 @@ class UPS(Asset, SNMPSim):
             return super().on_child_load_update(event, *args, **kwargs)
 
         # while running on battery, load propagation gets halted
+        # set _ups_on_battery to True, passed along each load event following this one
         asset_load_event = event.get_next_load_event(self)
+        asset_load_event._ups_on_battery = self.state.on_battery
         self._update_load(asset_load_event.load.old + event.load.difference)
-        asset_load_event._ups_on_battery = True
-
-        logger.info("on_child_load_update: asset_load_event: %s", asset_load_event)
-        # ensure that load doesn't change for the parent
-        # asset_load_event.load.new = asset_load_event.load.old
+        
         return asset_load_event
 
     @handler("InputVoltageUpEvent")

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -343,6 +343,7 @@ class UPS(Asset, SNMPSim):
 
         logger.info("on_child_load_update: asset_load_event: %s", asset_load_event)
         # ensure that load doesn't change for the parent
+        # asset_load_event.load.new = asset_load_event.load.old
         return asset_load_event
 
     @handler("InputVoltageUpEvent")

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -302,7 +302,7 @@ class UPS(Asset, SNMPSim):
 
         asset_event = event.get_next_power_event()
         asset_event.calc_load_from_volt()
-        
+
         if self.state.on_battery and asset_event.state.new:
             asset_event.out_volt.new = 120.0
         elif not asset_event.state.new:

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -342,7 +342,7 @@ class UPS(Asset, SNMPSim):
         asset_load_event = event.get_next_load_event(self)
         asset_load_event._ups_on_battery = self.state.on_battery
         self._update_load(asset_load_event.load.old + event.load.difference)
-        
+
         return asset_load_event
 
     @handler("InputVoltageUpEvent")

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -343,7 +343,6 @@ class UPS(Asset, SNMPSim):
 
         logger.info("on_child_load_update: asset_load_event: %s", asset_load_event)
         # ensure that load doesn't change for the parent
-        asset_load_event.load.new = asset_load_event.load.old
         return asset_load_event
 
     @handler("InputVoltageUpEvent")

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -424,6 +424,8 @@ class UPS(Asset, SNMPSim):
             asset_event.calc_load_from_volt()
             self._update_load(self.state.load + asset_event.load.difference)
 
+        logger.info("on_input_voltage_down: asset_event: %s", asset_event)
+
         return asset_event
 
     @property

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -301,12 +301,13 @@ class UPS(Asset, SNMPSim):
         state changes associated with it"""
 
         asset_event = event.get_next_power_event()
-        asset_event.calc_load_from_volt()
 
         if self.state.on_battery and asset_event.state.new:
             asset_event.out_volt.new = 120.0
         elif not asset_event.state.new:
             asset_event.out_volt.old = self.state.output_voltage
+
+        asset_event.calc_load_from_volt()
 
         super().set_redis_state_on_btn_press(event, args, kwargs)
 
@@ -341,7 +342,6 @@ class UPS(Asset, SNMPSim):
         asset_load_event = event.get_next_load_event(self)
         self._update_load(asset_load_event.load.old + event.load.difference)
 
-        logger.info("on_child_load_update: asset_load_event: %s", asset_load_event)
         # ensure that load doesn't change for the parent
         # asset_load_event.load.new = asset_load_event.load.old
         return asset_load_event

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -302,6 +302,8 @@ class UPS(Asset, SNMPSim):
 
         asset_event = event.get_next_power_event()
         asset_event.calc_load_from_volt()
+        logger.info("on_power_button_press: event: %s", event)
+        logger.info("on_power_button_press: asset_event: %s", asset_event)
 
         if self.state.on_battery and asset_event.state.new:
             asset_event.out_volt.new = 120.0

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -301,21 +301,17 @@ class UPS(Asset, SNMPSim):
         state changes associated with it"""
 
         asset_event = event.get_next_power_event()
+        asset_event.calc_load_from_volt()
 
         if self.state.on_battery and asset_event.state.new:
             asset_event.out_volt.new = 120.0
         elif not asset_event.state.new:
             asset_event.out_volt.old = self.state.output_voltage
 
-        asset_event.calc_load_from_volt()
-        
         super().set_redis_state_on_btn_press(event, args, kwargs)
 
         if event.name == "PowerButtonOnEvent" and self.state.on_battery:
             self._launch_battery_drain(t_reason=self.state.transfer_reason)
-
-        logger.info("on_power_button_press: event: %s", event)
-        logger.info("on_power_button_press: asset_event: %s", asset_event)
 
         return asset_event
 
@@ -424,8 +420,6 @@ class UPS(Asset, SNMPSim):
         else:
             asset_event.calc_load_from_volt()
             self._update_load(self.state.load + asset_event.load.difference)
-
-        logger.info("on_input_voltage_down: asset_event: %s", asset_event)
 
         return asset_event
 

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -302,8 +302,6 @@ class UPS(Asset, SNMPSim):
 
         asset_event = event.get_next_power_event()
         asset_event.calc_load_from_volt()
-        logger.info("on_power_button_press: event: %s", event)
-        logger.info("on_power_button_press: asset_event: %s", asset_event)
 
         if self.state.on_battery and asset_event.state.new:
             asset_event.out_volt.new = 120.0
@@ -314,6 +312,9 @@ class UPS(Asset, SNMPSim):
 
         if event.name == "PowerButtonOnEvent" and self.state.on_battery:
             self._launch_battery_drain(t_reason=self.state.transfer_reason)
+
+        logger.info("on_power_button_press: event: %s", event)
+        logger.info("on_power_button_press: asset_event: %s", asset_event)
 
         return asset_event
 

--- a/enginecore/enginecore/state/hardware/ups_asset.py
+++ b/enginecore/enginecore/state/hardware/ups_asset.py
@@ -301,13 +301,14 @@ class UPS(Asset, SNMPSim):
         state changes associated with it"""
 
         asset_event = event.get_next_power_event()
-        asset_event.calc_load_from_volt()
 
         if self.state.on_battery and asset_event.state.new:
             asset_event.out_volt.new = 120.0
         elif not asset_event.state.new:
             asset_event.out_volt.old = self.state.output_voltage
 
+        asset_event.calc_load_from_volt()
+        
         super().set_redis_state_on_btn_press(event, args, kwargs)
 
         if event.name == "PowerButtonOnEvent" and self.state.on_battery:

--- a/enginecore/enginecore/state/net/ws_server.py
+++ b/enginecore/enginecore/state/net/ws_server.py
@@ -390,9 +390,12 @@ class WebSocket(Component):
         if not event:
             return
 
-        logger.info("event: %s", event)
+        if event._asset.key == 3:
+            logger.info("event: %s", event)
+
         if not event.load.unchanged():
-            logger.info("\n!!!-------------------AssetLoadEvent (LOAD CHANGE) --------------------!!!")
+            if event._asset.key == 3:
+                logger.info("\n!!!-------------------AssetLoadEvent (LOAD CHANGE) --------------------!!!")
             client_request = ServerToClientRequests.asset_upd
             payload = {"key": event.asset.key, "load": event.load.new}
 

--- a/enginecore/enginecore/state/net/ws_server.py
+++ b/enginecore/enginecore/state/net/ws_server.py
@@ -390,12 +390,10 @@ class WebSocket(Component):
         if not event:
             return
 
-        if event._asset.key == 3:
+        if event._asset.key == 3 or 1:
             logger.info("event: %s", event)
 
         if not event.load.unchanged():
-            if event._asset.key == 3:
-                logger.info("\n!!!-------------------AssetLoadEvent (LOAD CHANGE) --------------------!!!")
             client_request = ServerToClientRequests.asset_upd
             payload = {"key": event.asset.key, "load": event.load.new}
 

--- a/enginecore/enginecore/state/net/ws_server.py
+++ b/enginecore/enginecore/state/net/ws_server.py
@@ -390,9 +390,6 @@ class WebSocket(Component):
         if not event:
             return
 
-        if event._asset.key == 3 or 1:
-            logger.info("event: %s", event)
-
         if not event.load.unchanged():
             client_request = ServerToClientRequests.asset_upd
             payload = {"key": event.asset.key, "load": event.load.new}

--- a/enginecore/enginecore/state/net/ws_server.py
+++ b/enginecore/enginecore/state/net/ws_server.py
@@ -390,7 +390,9 @@ class WebSocket(Component):
         if not event:
             return
 
+        logger.info("event: %s", event)
         if not event.load.unchanged():
+            logger.info("\n!!!-------------------AssetLoadEvent (LOAD CHANGE) --------------------!!!")
             client_request = ServerToClientRequests.asset_upd
             payload = {"key": event.asset.key, "load": event.load.new}
 


### PR DESCRIPTION
#171 Removed some code that was incorrectly halting load updates within ups_asset.py while a UPS was on battery. Added a property to load events to track ups battery state, and created an outlet-specific child_load_update handler to properly halt load propagation from a UPS that is currently on battery.