### PR TITLE
fix(dashboard): reversed power status colors red / green

### DIFF
--- a/dashboard/frontend/src/components/Assets/common/Led.jsx
+++ b/dashboard/frontend/src/components/Assets/common/Led.jsx
@@ -11,7 +11,7 @@ const Led = ({ powered, socketOn, x, y }) => {
   const color = powered
     ? socketOn
       ? colors.ledStatusOn
-      : colors.red
+      : colors.green
     : colors.ledStatusOff;
   return (
     <Rect x={x} y={y} width={10} height={10} fill={color} shadowBlur={3} />

--- a/dashboard/frontend/src/components/Canvas.jsx
+++ b/dashboard/frontend/src/components/Canvas.jsx
@@ -76,7 +76,7 @@ class Canvas extends Component {
         wireDrawing.push(
           <Line
             points={linePoints}
-            stroke={asset.status === 1 ? colors.green : colors.grey}
+            stroke={asset.status === 1 ? colors.red : colors.grey}
             strokeWidth={wireWidth}
             key={`${key}${connections[key].destKey}`}
             shadowBlur={3}

--- a/dashboard/frontend/src/components/common/PowerSwitch.jsx
+++ b/dashboard/frontend/src/components/common/PowerSwitch.jsx
@@ -27,9 +27,9 @@ function PowerSwitch({ onChange, checked, label, classes }) {
 
 const styles = {
   colorSwitchBase: {
-    color: colors.red,
+    color: colors.green,
     '&$colorChecked': {
-      color: colors.green,
+      color: colors.red,
       '& + $colorBar': {
         backgroundColor: colors.green,
       },

--- a/dashboard/frontend/src/styles/colors.js
+++ b/dashboard/frontend/src/styles/colors.js
@@ -8,7 +8,7 @@ export default {
   ledText: 'yellow',
   ledTextWhite: 'white',
   ledBackground: '#4d4d4d',
-  ledStatusOn: 'green',
+  ledStatusOn: 'red',
   ledStatusOff: 'grey',
   ledStroke: 'black',
 


### PR DESCRIPTION
#169 Changed green power on color to red for wires, status LEDs and the power switches